### PR TITLE
Clean up quote and escape - completing PR #87

### DIFF
--- a/htdocs/class/database/mysqldatabase.php
+++ b/htdocs/class/database/mysqldatabase.php
@@ -304,7 +304,7 @@ class XoopsMySQLDatabase extends XoopsDatabase
     {
         $this->deprecated();
 
-        return  str_replace("\\\"", '"', str_replace("\\&quot;", '&quot;', $this->conn->quote($string)));
+        return  $this->conn->quote($string);
     }
 
     /**
@@ -319,7 +319,8 @@ class XoopsMySQLDatabase extends XoopsDatabase
     {
         $this->deprecated();
 
-        return  str_replace("\\\"", '"', str_replace("\\&quot;", '&quot;', $string));
+        $string = $this->quote($input);
+        return substr($string, 1, -1);
     }
 
     /**


### PR DESCRIPTION
Part of this is undoing the bizarre unescaping done to the escaped string that was introduced in 2009 in sourceforge commit 3748. This is an inappropriate place to do this, as whatever it is trying to undo is not being done by the database escaping. If this breaks things, we need to find the root cause and fix that. This silliness must end; It is potentially insecure and violates the stated purpose of the quote() method in that it can corrupt data being stored instead of preserving it.

Eventually we may want to add the escape() to the main doctrine based connection, but this only adds it to the legacy layer, to match a corresponding change in in 2.5.7.
