### PR TITLE
Provide proper status and message from NullProvider.

### DIFF
--- a/htdocs/xoops_lib/Xoops/Core/Service/NullProvider.php
+++ b/htdocs/xoops_lib/Xoops/Core/Service/NullProvider.php
@@ -49,7 +49,8 @@ class NullProvider extends Provider
      */
     public function __construct(Manager $manager, $service)
     {
-        $this->response = new Response(null, true, null);
+        $this->response = new Response();
+        $this->response->setSuccess(false)->addErrorMessage(sprintf("No provider installed for %s", $service));
         parent::__construct($manager, $service);
     }
 


### PR DESCRIPTION
The response will now correctly return false for success and a message that no provider is installed.
