### PR TITLE
Fix ids of radio buttons inside tray

### DIFF
--- a/htdocs/class/xoopsform/formradio.php
+++ b/htdocs/class/xoopsform/formradio.php
@@ -156,7 +156,7 @@ class XoopsFormRadio extends XoopsFormElement
         $extra = ($this->getExtra() != '' ? " " . $this->getExtra() : '');
         $required = ($this->isRequired() ? ' required' : '');
         $ret = "";
-        $id_ele = 0;
+        static $id_ele = 0;
         foreach ($ele_options as $value => $name) {
             if (isset($ele_value) && $value == $ele_value) {
                 $ele_checked = " checked='checked'";


### PR DESCRIPTION
Repeat commit comment: In a case where you layout out radio buttons in a "tray" and so you are creating a series of radio button elements with the same name, they would previously all get the $id_ele of 1, and so their labels and ids would all match.  This change gives them unique ids, and labels, since the counter persists across all radio buttons in a given page load.
