### PR TITLE
Comments and notifications module uninstall actions

### DIFF
--- a/htdocs/modules/comments/include/install.php
+++ b/htdocs/modules/comments/include/install.php
@@ -10,10 +10,9 @@
 */
 
 /**
- * @copyright       The XOOPS Project http://sourceforge.net/projects/xoops/
- * @license         http://www.fsf.org/copyleft/gpl.html GNU public license
- * @author          trabis <lusopoemas@gmail.com>
- * @version         $Id$
+ * @copyright 2013-2014 The XOOPS Project http://sourceforge.net/projects/xoops/
+ * @license   GNU GPL 2 or greater (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @author    trabis <lusopoemas@gmail.com>
  */
 
 function xoops_module_install_comments(&$module)
@@ -45,7 +44,7 @@ function xoops_module_install_comments(&$module)
     return true;
 }
 
-function xoops_module_uninstall_comments(&$module)
+function xoops_module_pre_uninstall_comments(&$module)
 {
     $xoops = Xoops::getInstance();
     XoopsLoad::loadFile($xoops->path('modules/comments/class/helper.php'));

--- a/htdocs/modules/comments/xoops_version.php
+++ b/htdocs/modules/comments/xoops_version.php
@@ -13,12 +13,10 @@
  * Comments
  *
  * @copyright       The XOOPS Project http://sourceforge.net/projects/xoops/
- * @license         GNU GPL 2 (http://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
+ * @license         GNU GPL 2 (http://www.gnu.org/licenses/gpl-2.0.html)
  * @author          trabis <lusopoemas@gmail.com>
  * @version         $Id$
  */
-
-$xoops->loadLanguage('modinfo', $dirname);
 
 $modversion                = array();
 $modversion['name']        = _MI_COMMENTS_NAME;
@@ -28,7 +26,7 @@ $modversion['author']      = 'Trabis';
 $modversion['nickname']    = 'trabis';
 $modversion['credits']     = 'The XOOPS Project';
 $modversion['license']     = 'GNU GPL 2.0';
-$modversion['license_url'] = 'www.gnu.org/licenses/gpl-2.0.html/';
+$modversion['license_url'] = 'http://www.gnu.org/licenses/gpl-2.0.html';
 $modversion['official']    = 1;
 $modversion['help']        = 'page=help';
 $modversion['image']       = 'images/logo.png';

--- a/htdocs/modules/notifications/include/install.php
+++ b/htdocs/modules/notifications/include/install.php
@@ -10,10 +10,9 @@
 */
 
 /**
- * @copyright       The XOOPS Project http://sourceforge.net/projects/xoops/
- * @license         http://www.fsf.org/copyleft/gpl.html GNU public license
- * @author          trabis <lusopoemas@gmail.com>
- * @version         $Id$
+ * @copyright 2013-2014 The XOOPS Project http://sourceforge.net/projects/xoops/
+ * @license   GNU GPL 2 or greater (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @author    trabis <lusopoemas@gmail.com>
  */
 
 function xoops_module_install_notifications(&$module)
@@ -45,7 +44,7 @@ function xoops_module_install_notifications(&$module)
     return true;
 }
 
-function xoops_module_uninstall_notifications(&$module)
+function xoops_module_pre_uninstall_notifications(&$module)
 {
     $xoops = Xoops::getInstance();
     XoopsLoad::loadFile($xoops->path('modules/notifications/class/helper.php'));

--- a/htdocs/modules/notifications/xoops_version.php
+++ b/htdocs/modules/notifications/xoops_version.php
@@ -11,7 +11,7 @@
 
 /**
  * @copyright       The XOOPS Project http://sourceforge.net/projects/xoops/
- * @license         GNU GPL 2 (http://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
+ * @license         GNU GPL 2 (http://www.gnu.org/licenses/gpl-2.0.html)
  * @author          trabis <lusopoemas@gmail.com>
  * @version         $Id$
  */
@@ -24,11 +24,11 @@ $modversion['author']      = 'Trabis';
 $modversion['nickname']    = 'trabis';
 $modversion['credits']     = 'The XOOPS Project';
 $modversion['license']     = 'GNU GPL 2.0';
-$modversion['license_url'] = 'www.gnu.org/licenses/gpl-2.0.html/';
+$modversion['license_url'] = 'http://www.gnu.org/licenses/gpl-2.0.html';
 $modversion['official']    = 1;
-//$modversion['help']           = 'page=help';
-$modversion['image']   = 'images/logo.png';
-$modversion['dirname'] = 'notifications';
+//$modversion['help']      = 'page=help';
+$modversion['image']       = 'images/logo.png';
+$modversion['dirname']     = 'notifications';
 
 //about
 $modversion['release_date']        = '2012/11/25';


### PR DESCRIPTION
Switch comments and notifications modules' uninstall activity to 'pre_uninstall' hook. Since the module is still installed when the hook is called, the module helper can be used reliably. This change, in addition to previous changes, resolves #17
