### PR TITLE
Add getConfigs() method to module helper HelperAbstract

### DIFF
--- a/UnitTestXoops/xoopsLib/Xoops/Module/Helper/HelperAbstractTest.php
+++ b/UnitTestXoops/xoopsLib/Xoops/Module/Helper/HelperAbstractTest.php
@@ -7,22 +7,22 @@ class Xoops_Module_Helper_AbstractTestInstance extends Xoops\Module\Helper\Helpe
 	{
 		return $this->_dirname;
 	}
-	
+
 	public function setDirname($dir)
 	{
 		return parent::setDirname($dir);
 	}
-	
+
 	public function getDebug()
 	{
 		return $this->_debug;
 	}
-	
+
 	public function setDebug($debug)
 	{
 		return parent::setDebug($debug);
 	}
-    
+
 	public function clearModule()
 	{
 		$this->_module = null;
@@ -48,7 +48,7 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
     public function test_init()
 	{
 		$instance = new $this->myClass();
-		
+
 		$x = $instance->init();
 		$this->assertSame(null, $x);
     }
@@ -56,11 +56,11 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
     public function test_setDirname()
 	{
 		$instance = new $this->myClass();
-		
+
 		$dir = 'dirname';
 		$x = $instance->setDirname($dir);
 		$this->assertSame(null, $x);
-		
+
 		$x = $instance->getDirname();
 		$this->assertSame($dir, $x);
     }
@@ -68,11 +68,11 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
 	public function test_setDebug()
 	{
 		$instance = new $this->myClass();
-		
+
 		$debug = true;
 		$x = $instance->setDebug($debug);
 		$this->assertSame(null, $x);
-		
+
 		$x = $instance->getDebug();
 		$this->assertSame($debug, $x);
     }
@@ -82,7 +82,7 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
 		$instance = $this->myClass;
 		$x = $instance::getInstance();
 		$this->assertInstanceOf($this->myClass, $x);
-		
+
 		$y = $instance::getInstance();
 		$this->assertSame($x, $y);
     }
@@ -91,7 +91,7 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
 	{
 		$class = $this->myClass;
 		$instance = $class::getInstance();
-		
+
 		$x = $instance->getModule();
 		$this->assertInstanceOf('XoopsModule', $x);
     }
@@ -100,7 +100,7 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
 	{
 		$class = $this->myClass;
 		$instance = $class::getInstance();
-		
+
 		$x = $instance->xoops();
 		$this->assertInstanceOf('Xoops', $x);
     }
@@ -109,7 +109,7 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
 	{
 		$class = $this->myClass;
 		$instance = $class::getInstance();
-		
+
         $name = 'sitename';
         $instance->setDirname('system');
 		$x = $instance->getConfig($name);
@@ -117,11 +117,24 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
 		$this->assertTrue(!empty($x));
     }
 
+    public function test_getConfigs()
+    {
+        $class = $this->myClass;
+        $instance = $class::getInstance();
+
+        $name = 'sitename';
+        $instance->setDirname('system');
+        $x = $instance->getConfigs();
+        $this->assertFalse(empty($x));
+        $this->assertTrue(is_array($x));
+        $this->assertArrayHasKey($name, $x);
+    }
+
 	public function test_getHandler()
 	{
 		$class = $this->myClass;
 		$instance = $class::getInstance();
-		
+
         $instance->setDirname('avatars');
 		$x = $instance->getHandler('avatar');
 		$this->assertInstanceOf('AvatarsAvatarHandler', $x);
@@ -132,11 +145,11 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
 	{
 		$class = $this->myClass;
 		$instance = $class::getInstance();
-		
+
         $instance->clearModule();
         $instance->setDirname('avatars');
 		$instance->disableCache();
-        
+
         $x = $instance->xoops()->getModuleConfig('module_cache');
 		$this->assertTrue(is_array($x));
     }
@@ -155,7 +168,7 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
 	{
 		$class = $this->myClass;
 		$instance = $class::getInstance();
-		
+
 		$x = $instance->getUserGroups();
 		$this->assertSame(XOOPS_GROUP_ANONYMOUS, $x);
     }
@@ -164,21 +177,22 @@ class Xoops_Module_Helper_AbstractTest extends MY_UnitTestCase
 	{
 		$class = $this->myClass;
 		$instance = $class::getInstance();
-		
+
         $name = 'dirname';
         $instance->setDirname($name);
 		$x = $instance->url($name);
 		$this->assertSame($name, basename($x));
 		$this->assertSame($name, basename(dirname($x)));
 		$this->assertSame('modules', basename(dirname(dirname(($x)))));
-		$this->assertSame('htdocs', basename(dirname(dirname(dirname(($x))))));
+        // modules is the top level, anything above in URL is install dependant
+		//$this->assertSame('htdocs', basename(dirname(dirname(dirname($x)))));
     }
 
 	public function test_path()
 	{
 		$class = $this->myClass;
 		$instance = $class::getInstance();
-		
+
         $instance->setDirname('system');
 		$x = $instance->path('class');
 		$this->assertSame('class', basename($x));

--- a/htdocs/modules/codex/module-helper.php
+++ b/htdocs/modules/codex/module-helper.php
@@ -53,19 +53,16 @@ if ($helper = Xoops\Module\Helper::getHelper('search')) {
 }
 
 //Some examples
-if ($helper = Xoops\Module\Helper::getHelper('publisher')) {
+if ($helper = Xoops\Module\Helper::getHelper('codex')) {
     Xoops_Utils::dumpVar($helper->getModule()->getVar('name'));
+    Xoops_Utils::dumpVar($helper->url('index.php'));
 }
 
 if ($helper = Xoops\Module\Helper::getHelper('search')) {
-    Xoops_Utils::dumpVar($helper->getModule()->getVar('name'));
+    Xoops_Utils::dumpVar($helper->getConfigs());
 }
 
-if ($helper = Xoops\Module\Helper::getHelper('notifications')) {
-    Xoops_Utils::dumpVar($helper->getModule()->getVar('name'));
-}
-
-if ($helper = Xoops\Module\Helper::getHelper('menus')) {
+if ($helper = Xoops\Module\Helper::getHelper('nosuchmodule')) {
     Xoops_Utils::dumpVar($helper->getModule()->getVar('name'));
 }
 

--- a/htdocs/xoops_lib/Xoops/Module/Helper/HelperAbstract.php
+++ b/htdocs/xoops_lib/Xoops/Module/Helper/HelperAbstract.php
@@ -103,6 +103,18 @@ abstract class HelperAbstract
     }
 
     /**
+     * getConfigs
+     *
+     * @return array of config items for module
+     */
+    public function getConfigs()
+    {
+        $result = $this->xoops()->getModuleConfigs($this->_dirname);
+        $this->_addLog("Getting configs for {$this->_dirname} module");
+        return $result;
+    }
+
+    /**
      * @param string $name
      *
      * @return XoopsObjectHandler


### PR DESCRIPTION
This returns an array of all of a module's configs. Added to unit test and codex example.
