### PR TITLE
Standardize JSON output

### DIFF
--- a/htdocs/install/page_configsave.php
+++ b/htdocs/install/page_configsave.php
@@ -127,11 +127,13 @@ if (isset($composer->extra) && is_object($composer->extra)) {
 } else {
     $composer->extra['xoops_modules_path'] = $xoops_modules_path;
 }
-$jsonEncodeOpts = 0;
-if (defined('JSON_PRETTY_PRINT') && defined('JSON_UNESCAPED_SLASHES')) {
-    $jsonEncodeOpts = $jsonEncodeOpts | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
-}
-file_put_contents($composer_path, json_encode($composer, $jsonEncodeOpts));
+$composerOut = \Composer\Json\JsonFormatter::format(json_encode($composer));
+file_put_contents($composer_path, $composerOut);
+//$jsonEncodeOpts = 0;
+//if (defined('JSON_PRETTY_PRINT') && defined('JSON_UNESCAPED_SLASHES')) {
+//    $jsonEncodeOpts = $jsonEncodeOpts | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
+//}
+//file_put_contents($composer_path, json_encode($composer, $jsonEncodeOpts));
 
 $settings['authorized'] = false;
 if (empty($error)) {

--- a/htdocs/xoops_lib/Xoops/Core/JsonFormatter.php
+++ b/htdocs/xoops_lib/Xoops/Core/JsonFormatter.php
@@ -1,0 +1,129 @@
+<?php
+namespace Xoops\Core;
+
+/*
+ * This file is part of Composer.
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+//namespace Composer\Json;
+
+/**
+ * Formats json strings used for php < 5.4 because the json_encode doesn't
+ * supports the flags JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE
+ * in these versions
+ *
+ * @author Konstantin Kudryashiv <ever.zet@gmail.com>
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class JsonFormatter
+{
+    /**
+     *
+     * This code is based on the function found at:
+     *  http://recursive-design.com/blog/2008/03/11/format-json-with-php/
+     *
+     * Originally licensed under MIT by Dave Perrett <mail@recursive-design.com>
+     *
+     *
+     * @param  string $json
+     * @param  bool   $unescapeUnicode Un escape unicode
+     * @param  bool   $unescapeSlashes Un escape slashes
+     * @return string
+     */
+    public static function format($json, $unescapeUnicode, $unescapeSlashes)
+    {
+        $result = '';
+        $pos = 0;
+        $strLen = strlen($json);
+        $indentStr = '    ';
+        $newLine = "\n";
+        $outOfQuotes = true;
+        $buffer = '';
+        $noescape = true;
+
+        for ($i = 0; $i < $strLen; $i++) {
+            // Grab the next character in the string
+            $char = substr($json, $i, 1);
+
+            // Are we inside a quoted string?
+            if ('"' === $char && $noescape) {
+                $outOfQuotes = !$outOfQuotes;
+            }
+
+            if (!$outOfQuotes) {
+                $buffer .= $char;
+                $noescape = '\\' === $char ? !$noescape : true;
+                continue;
+            } elseif ('' !== $buffer) {
+                if ($unescapeSlashes) {
+                    $buffer = str_replace('\\/', '/', $buffer);
+                }
+
+                if ($unescapeUnicode && function_exists('mb_convert_encoding')) {
+                    // http://stackoverflow.com/questions/2934563/how-to-decode-unicode-escape-sequences-like-u00ed-to-proper-utf-8-encoded-cha
+                    $buffer = preg_replace_callback('/(\\\\+)u([0-9a-f]{4})/i', function ($match) {
+                        $l = strlen($match[1]);
+
+                        if ($l % 2) {
+                            return str_repeat('\\', $l - 1) . mb_convert_encoding(
+                                pack('H*', $match[2]),
+                                'UTF-8',
+                                'UCS-2BE'
+                            );
+                        }
+
+                        return $match[0];
+                    }, $buffer);
+                }
+
+                $result .= $buffer.$char;
+                $buffer = '';
+                continue;
+            }
+
+            if (':' === $char) {
+                // Add a space after the : character
+                $char .= ' ';
+            } elseif (('}' === $char || ']' === $char)) {
+                $pos--;
+                $prevChar = substr($json, $i - 1, 1);
+
+                if ('{' !== $prevChar && '[' !== $prevChar) {
+                    // If this character is the end of an element,
+                    // output a new line and indent the next line
+                    $result .= $newLine;
+                    for ($j = 0; $j < $pos; $j++) {
+                        $result .= $indentStr;
+                    }
+                } else {
+                    // Collapse empty {} and []
+                    $result = rtrim($result)."\n\n".$indentStr;
+                }
+            }
+
+            $result .= $char;
+
+            // If the last character was the beginning of an element,
+            // output a new line and indent the next line
+            if (',' === $char || '{' === $char || '[' === $char) {
+                $result .= $newLine;
+
+                if ('{' === $char || '[' === $char) {
+                    $pos++;
+                }
+
+                for ($j = 0; $j < $pos; $j++) {
+                    $result .= $indentStr;
+                }
+            }
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
json_encode options that we should use for editable json output (like composer.json) are only available on PHP 5.4 and above. This borrows the same routine used in composer, so that we get consistent easily editable 'pretty printed' output under all PHP versions.
