### PR TITLE
Fixed - User registration date for LDAP / AD

### DIFF
--- a/htdocs/xoops_lib/Xoops/Auth/Provisioning.php
+++ b/htdocs/xoops_lib/Xoops/Auth/Provisioning.php
@@ -180,6 +180,7 @@ class Xoops_Auth_Provisioning
         $newuser->setVar('theme', $this->theme_set);
         $newuser->setVar('umode', $this->com_mode);
         $newuser->setVar('uorder', $this->com_order);
+        $newuser->setVar('user_regdate', time());
        $this->setVarsMapping($newuser, $data);
 
         if ($member_handler->insertUser($newuser)) {


### PR DESCRIPTION
Using the current date as the registration date for account provisioning (LDAP etc.). Otherwise date registered displays as 1970-01-01 in the user admin section.
