### PR TITLE
Introduce XoopsBaseConfig object

### DIFF
--- a/UnitTestXoops/xoopsLib/Xoops/Core/YamlTest.php
+++ b/UnitTestXoops/xoopsLib/Xoops/Core/YamlTest.php
@@ -3,19 +3,22 @@ namespace Xoops\Core;
 
 require_once(dirname(__FILE__).'/../../../init_mini.php');
 
-/**
-* PHPUnit special settings :
-* @backupGlobals disabled
-* @backupStaticAttributes disabled
-*/
-class YamlTest extends \MY_UnitTestCase
+class YamlTest extends \PHPUnit_Framework_TestCase
 {
-    protected $myclass = 'Xoops\Core\Yaml';
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+    }
 
-    public function test___construct()
-	{
-		$instance = new $this->myclass();
-		$this->assertInstanceOf($this->myclass, $instance);
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
     }
 
     /**
@@ -40,7 +43,7 @@ class YamlTest extends \MY_UnitTestCase
      * @covers Xoops\Core\Yaml::read
      */
     public function testSaveAndRead()
-	{
+    {
         $tmpfname = tempnam(sys_get_temp_dir(), 'TEST');
         $inputArray = array('one' => 1, 'two' => array(1,2), 'three' => '');
 
@@ -49,6 +52,43 @@ class YamlTest extends \MY_UnitTestCase
         $this->assertGreaterThan(0, $byteCount);
 
         $outputArray = Yaml::read($tmpfname);
+        $this->assertTrue(is_array($outputArray));
+        $this->assertSame($inputArray, $outputArray);
+
+        unlink($tmpfname);
+    }
+
+    /**
+     * @covers Xoops\Core\Yaml::dumpWrapped
+     * @covers Xoops\Core\Yaml::loadWrapped
+     */
+    public function testDumpAndLoadWrapped()
+    {
+        $inputArray = array('one' => 1, 'two' => array(1,2), 'three' => '');
+
+        $string = Yaml::dumpWrapped($inputArray);
+        $this->assertTrue(!empty($string));
+        $this->assertTrue(is_string($string));
+
+        $outputArray = Yaml::loadWrapped((string) $string);
+        $this->assertTrue(is_array($outputArray));
+        $this->assertSame($inputArray, $outputArray);
+    }
+
+    /**
+     * @covers Xoops\Core\Yaml::saveWrapped
+     * @covers Xoops\Core\Yaml::readWrapped
+     */
+    public function testSaveAndReadWrapped()
+    {
+        $tmpfname = tempnam(sys_get_temp_dir(), 'TEST');
+        $inputArray = array('one' => 1, 'two' => array(1,2), 'three' => '');
+
+        $byteCount = Yaml::saveWrapped($inputArray, $tmpfname);
+        $this->assertFalse($byteCount === false);
+        $this->assertGreaterThan(0, $byteCount);
+
+        $outputArray = Yaml::readWrapped($tmpfname);
         $this->assertTrue(is_array($outputArray));
         $this->assertSame($inputArray, $outputArray);
 

--- a/htdocs/browse.php
+++ b/htdocs/browse.php
@@ -24,7 +24,7 @@ require_once __DIR__ . '/mainfile.php';
 
 //error_reporting(0);
 
-require_once XOOPS_ROOT_PATH . '/class/xoopsload.php';
+//require_once XOOPS_ROOT_PATH . '/class/xoopsload.php';
 
 $xoops = Xoops::getInstance();
 //$xoops->pathTranslation(); // alread run in Xoops __construct

--- a/htdocs/class/XoopsBaseConfig.php
+++ b/htdocs/class/XoopsBaseConfig.php
@@ -1,0 +1,225 @@
+<?php
+/*
+ You may not change or alter any portion of this comment or credits
+ of supporting developers from this source code or any supporting source code
+ which is considered copyrighted (c) material of the original comment or credit authors.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+use Xoops\Core\Yaml;
+
+/**
+ * XoopsBaseConfig holds the base XOOPS configs needed to locate key paths and
+ * enable database access
+ *
+ * @category  XoopsBaseConfig
+ * @package   XoopsBaseConfig
+ * @author    Richard Griffith <richard@geekwright.com>
+ * @copyright 2015 The XOOPS Project http://sourceforge.net/projects/xoops/
+ * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      http://xoops.org
+ */
+class XoopsBaseConfig
+{
+    /**
+     * @var string[] $configs
+     */
+    private static $configs = array();
+
+    /**
+     * __construct
+     * @param string|string[] $configs fully qualified name of configuration file
+     *                                 or configuration array
+     * @return void
+     */
+    final private function __construct($config)
+    {
+
+        if (!class_exists('XoopsLoad', false)) {
+            include __DIR__ . '/xoopsload.php';
+        }
+        if (is_string($config)) {
+            $yamlString = file_get_contents($config);
+            $libPath = $this->solveChickenEgg($yamlString);
+            \XoopsLoad::startAutoloader($libPath);
+            self::$configs = Yaml::loadWrapped($yamlString);
+        } elseif (is_array($config)) {
+            self::$configs = $config;
+            \XoopsLoad::startAutoloader(self::$configs['lib-path']);
+        }
+    }
+
+    /**
+     * Allow one instance only!
+     *
+     * @param string|string[] $configs fully qualified name of configuration file
+     *                                 or configuration array
+     *
+     * @return XoopsBaseConfig instance
+     */
+    final public static function getInstance($config = '')
+    {
+        static $instance = false;
+
+        if (!$instance && !empty($config)) {
+            $instance = new \XoopsBaseConfig($config);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * solveChickenEgg
+     *
+     * The yaml file we can load has the path we need to set up the autoloader we need
+     * to reach our yaml library. We solve this by looking through the raw yaml file
+     * contents to locate our data. This works only because there is a unique key that
+     * should not be duplicated in a limited and known data set.
+     *
+     * Not pretty, but this way we get full access to xoops from a single known path.
+     *
+     * @param string $filecontents contents of the yaml configuration file
+     *
+     * @return string the extracted lib-path value
+     */
+    final private function solveChickenEgg($filecontents)
+    {
+        $match = array();
+        $matched = preg_match('/[.\v]*^lib-path\h*\:\h*[\']?([^\'\v]*)[\']?\h*$[.\v]*/m', $filecontents, $match);
+
+        return trim($match[1]);
+    }
+
+    /**
+     * Retrieve an attribute value.
+     *
+     * @param string $name name of an attribute
+     *
+     * @return mixed value of the attribute, or null if not set.
+     */
+    final public static function get($name)
+    {
+        if (isset(self::$configs[$name])) {
+            return self::$configs[$name];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get a copy of all base configurations
+     *
+     * @return array of of all attributes
+     */
+    final public function getAll()
+    {
+        return self::$configs;
+    }
+
+    /**
+     * Establish backward compatibility defines
+     *
+     * @return void
+     */
+    final public function establishBCDefines()
+    {
+        if (defined('XOOPS_ROOT_PATH')) {
+            return;
+        }
+
+        // Physical path to the XOOPS documents (served) directory WITHOUT trailing slash
+        define('XOOPS_ROOT_PATH', XoopsBaseConfig::get('root-path'));
+
+        // For forward compatibility
+        // Physical path to the XOOPS library directory WITHOUT trailing slash
+        define('XOOPS_PATH', XoopsBaseConfig::get('lib-path'));
+        // Physical path to the XOOPS datafiles (writable) directory WITHOUT trailing slash
+        define('XOOPS_VAR_PATH', XoopsBaseConfig::get('var-path'));
+        // Alias of XOOPS_PATH, for compatibility, temporary solution
+        define("XOOPS_TRUST_PATH", XoopsBaseConfig::get('trust-path'));
+
+        // URL Association for SSL and Protocol Compatibility
+        define('XOOPS_PROT', XoopsBaseConfig::get('prot'));
+
+        // XOOPS Virtual Path (URL)
+        // Virtual path to your main XOOPS directory WITHOUT trailing slash
+        // Example: define('XOOPS_URL', 'http://localhost/xoopscore');
+        define('XOOPS_URL', XoopsBaseConfig::get('url'));
+
+        // Secure file
+        // require XOOPS_VAR_PATH . '/data/secure.php';
+
+        // Database
+        // Choose the database to be used
+        define('XOOPS_DB_TYPE', XoopsBaseConfig::get('db-type'));
+
+        // Set the database charset if applicable
+        define("XOOPS_DB_CHARSET", XoopsBaseConfig::get('db-charset'));
+
+        // Table Prefix
+        // This prefix will be added to all new tables created to avoid name conflict in the database.
+        define('XOOPS_DB_PREFIX', XoopsBaseConfig::get('db-prefix'));
+
+        // Database Hostname
+        // Hostname of the database server. If you are unsure, "localhost" works in most cases.
+        define('XOOPS_DB_HOST', XoopsBaseConfig::get('db-host'));
+
+        // Database Username
+        // Your database user account on the host
+        define('XOOPS_DB_USER', XoopsBaseConfig::get('db-user'));
+
+        // Database Password
+        // Password for your database user account
+        define('XOOPS_DB_PASS', XoopsBaseConfig::get('db-pass'));
+
+        // Database Name
+        // The name of database on the host.
+        define('XOOPS_DB_NAME', XoopsBaseConfig::get('db-name'));
+
+        // persistent connection is no longer supported
+        define("XOOPS_DB_PCONNECT", XoopsBaseConfig::get('db-pconnect'));
+
+        // Serialized connection parameter
+        // This is built by the installer and includes all connection parameters
+        define('XOOPS_DB_PARAMETERS', serialize(XoopsBaseConfig::get('db-parameters')));
+
+        define('XOOPS_COOKIE_DOMAIN', XoopsBaseConfig::get('cookie-domain'));
+
+    }
+
+    /**
+     * Create a working environment from traditional mainfile environment
+     *
+     * @return void
+     */
+    final public static function bootstrapTransition()
+    {
+        $parts = parse_url(XOOPS_URL . '/');
+
+        $configs = array(
+            'root-path' => XOOPS_ROOT_PATH,
+            'lib-path' => XOOPS_PATH,
+            'var-path' => XOOPS_VAR_PATH,
+            'trust-path' => XOOPS_TRUST_PATH,
+            'url' => XOOPS_URL,
+            'prot' => XOOPS_PROT, // $parts['scheme'] . '://',
+            'asset-path' => XOOPS_ROOT_PATH . '/assets',
+            'asset-url' => XOOPS_URL . '/assets',
+            'cookie-domain' => $parts['host'],
+            'cookie-path' => $parts['path'],
+            'db-type' => XOOPS_DB_TYPE,
+            'db-charset' => XOOPS_DB_CHARSET,
+            'db-prefix' => XOOPS_DB_PREFIX,
+            'db-host' => XOOPS_DB_HOST,
+            'db-user' => XOOPS_DB_USER,
+            'db-pass' => XOOPS_DB_PASS,
+            'db-name' => XOOPS_DB_NAME,
+            'db-pconnect' => XOOPS_DB_PCONNECT,
+            'db-parameters' => unserialize(XOOPS_DB_PARAMETERS),
+        );
+        self::getInstance($configs);
+    }
+}

--- a/htdocs/class/XoopsBaseConfig.php
+++ b/htdocs/class/XoopsBaseConfig.php
@@ -31,9 +31,8 @@ class XoopsBaseConfig
 
     /**
      * __construct
-     * @param string|string[] $configs fully qualified name of configuration file
-     *                                 or configuration array
-     * @return void
+     * @param string|string[] $config fully qualified name of configuration file
+     *                                or configuration array
      */
     final private function __construct($config)
     {
@@ -55,8 +54,8 @@ class XoopsBaseConfig
     /**
      * Allow one instance only!
      *
-     * @param string|string[] $configs fully qualified name of configuration file
-     *                                 or configuration array
+     * @param string|string[] $config fully qualified name of configuration file
+     *                                or configuration array
      *
      * @return XoopsBaseConfig instance
      */
@@ -90,7 +89,7 @@ class XoopsBaseConfig
         $match = array();
         $matched = preg_match('/[.\v]*^lib-path\h*\:\h*[\']?([^\'\v]*)[\']?\h*$[.\v]*/m', $filecontents, $match);
 
-        return trim($match[1]);
+        return $matched ? trim($match[1]) : '';
     }
 
     /**
@@ -131,62 +130,62 @@ class XoopsBaseConfig
         }
 
         // Physical path to the XOOPS documents (served) directory WITHOUT trailing slash
-        define('XOOPS_ROOT_PATH', XoopsBaseConfig::get('root-path'));
+        define('XOOPS_ROOT_PATH', self::get('root-path'));
 
         // For forward compatibility
         // Physical path to the XOOPS library directory WITHOUT trailing slash
-        define('XOOPS_PATH', XoopsBaseConfig::get('lib-path'));
+        define('XOOPS_PATH', self::get('lib-path'));
         // Physical path to the XOOPS datafiles (writable) directory WITHOUT trailing slash
-        define('XOOPS_VAR_PATH', XoopsBaseConfig::get('var-path'));
+        define('XOOPS_VAR_PATH', self::get('var-path'));
         // Alias of XOOPS_PATH, for compatibility, temporary solution
-        define("XOOPS_TRUST_PATH", XoopsBaseConfig::get('trust-path'));
+        define("XOOPS_TRUST_PATH", self::get('trust-path'));
 
         // URL Association for SSL and Protocol Compatibility
-        define('XOOPS_PROT', XoopsBaseConfig::get('prot'));
+        define('XOOPS_PROT', self::get('prot'));
 
         // XOOPS Virtual Path (URL)
         // Virtual path to your main XOOPS directory WITHOUT trailing slash
         // Example: define('XOOPS_URL', 'http://localhost/xoopscore');
-        define('XOOPS_URL', XoopsBaseConfig::get('url'));
+        define('XOOPS_URL', self::get('url'));
 
         // Secure file
         // require XOOPS_VAR_PATH . '/data/secure.php';
 
         // Database
         // Choose the database to be used
-        define('XOOPS_DB_TYPE', XoopsBaseConfig::get('db-type'));
+        define('XOOPS_DB_TYPE', self::get('db-type'));
 
         // Set the database charset if applicable
-        define("XOOPS_DB_CHARSET", XoopsBaseConfig::get('db-charset'));
+        define("XOOPS_DB_CHARSET", self::get('db-charset'));
 
         // Table Prefix
         // This prefix will be added to all new tables created to avoid name conflict in the database.
-        define('XOOPS_DB_PREFIX', XoopsBaseConfig::get('db-prefix'));
+        define('XOOPS_DB_PREFIX', self::get('db-prefix'));
 
         // Database Hostname
         // Hostname of the database server. If you are unsure, "localhost" works in most cases.
-        define('XOOPS_DB_HOST', XoopsBaseConfig::get('db-host'));
+        define('XOOPS_DB_HOST', self::get('db-host'));
 
         // Database Username
         // Your database user account on the host
-        define('XOOPS_DB_USER', XoopsBaseConfig::get('db-user'));
+        define('XOOPS_DB_USER', self::get('db-user'));
 
         // Database Password
         // Password for your database user account
-        define('XOOPS_DB_PASS', XoopsBaseConfig::get('db-pass'));
+        define('XOOPS_DB_PASS', self::get('db-pass'));
 
         // Database Name
         // The name of database on the host.
-        define('XOOPS_DB_NAME', XoopsBaseConfig::get('db-name'));
+        define('XOOPS_DB_NAME', self::get('db-name'));
 
         // persistent connection is no longer supported
-        define("XOOPS_DB_PCONNECT", XoopsBaseConfig::get('db-pconnect'));
+        define("XOOPS_DB_PCONNECT", self::get('db-pconnect'));
 
         // Serialized connection parameter
         // This is built by the installer and includes all connection parameters
-        define('XOOPS_DB_PARAMETERS', serialize(XoopsBaseConfig::get('db-parameters')));
+        define('XOOPS_DB_PARAMETERS', serialize(self::get('db-parameters')));
 
-        define('XOOPS_COOKIE_DOMAIN', XoopsBaseConfig::get('cookie-domain'));
+        define('XOOPS_COOKIE_DOMAIN', self::get('cookie-domain'));
 
     }
 

--- a/htdocs/class/xoopsload.php
+++ b/htdocs/class/xoopsload.php
@@ -549,12 +549,25 @@ class XoopsLoad
             exit('Security check: Illegal character in filename');
         }
     }
-}
 
-if (!defined('XOOPS_AUTOLOAD')) {
-    define('XOOPS_AUTOLOAD', true);
-    spl_autoload_register(array('XoopsLoad', 'load'));
-    if (!XOOPS_PATH == '') {
-        include XOOPS_PATH . '/vendor/autoload.php';
+    /**
+     * startAutoloader enable the autoloader
+     *
+     * @param string $path path of the library directory where composer managed
+     *                     vendor directory can be found.
+     * @return void
+     */
+    public static function startAutoloader($path)
+    {
+        static $libPath = null;
+
+        if ($libPath === null) {
+            $loaderPath = $path . '/vendor/autoload.php';
+            if (self::fileExists($loaderPath)) {
+                $libPath = $path;
+                include $loaderPath;
+            }
+            spl_autoload_register(array('XoopsLoad', 'load'));
+        }
     }
 }

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -10,12 +10,20 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
  * @copyright The XOOPS Project http://sourceforge.net/projects/xoops/
- * @license GNU GPL 2 (http://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
- * @package kernel
- * @version $Id$
+ * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @package   kernel
  */
 
 defined('XOOPS_MAINFILE_INCLUDED') or die('Restricted access');
+
+/**
+ * Include XoopsLoad
+ */
+if (!class_exists('XoopsLoad', false)) {
+    require_once dirname(__DIR__). '/class/XoopsBaseConfig.php';
+    XoopsBaseConfig::bootstrapTransition();
+    trigger_error('Patch mainfile.php for XoopsBaseConfig');
+}
 
 global $xoops;
 $GLOBALS['xoops'] =& $xoops;
@@ -34,11 +42,6 @@ defined('NWLINE')or define('NWLINE', "\n");
  */
 include_once XOOPS_ROOT_PATH . DS . 'include' . DS . 'defines.php';
 include_once XOOPS_ROOT_PATH . DS . 'include' . DS . 'version.php';
-
-/**
- * Include XoopsLoad
- */
-require_once XOOPS_ROOT_PATH . DS . 'class' . DS . 'xoopsload.php';
 
 /**
  * We now have autoloader, so start Patchwork\UTF8

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -17,12 +17,16 @@
 defined('XOOPS_MAINFILE_INCLUDED') or die('Restricted access');
 
 /**
- * Include XoopsLoad
+ * Include XoopsLoad - this should have been done in mainfile.php, but there is
+ * no update yet, so only only new installs get the change in mainfile.dist.php
+ * automatically.
+ *
+ * Temorarily try and fix, but set up a (delayed) warning
  */
 if (!class_exists('XoopsLoad', false)) {
     require_once dirname(__DIR__). '/class/XoopsBaseConfig.php';
     XoopsBaseConfig::bootstrapTransition();
-    trigger_error('Patch mainfile.php for XoopsBaseConfig');
+    $delayedWarning = 'Patch mainfile.php for XoopsBaseConfig';
 }
 
 global $xoops;
@@ -74,6 +78,13 @@ $psr4loader->register();
 $xoops->events()->triggerEvent('core.include.common.psr4loader', $psr4loader);
 $xoops->events()->triggerEvent('core.include.common.classmaps');
 $xoops->events()->triggerEvent('core.include.common.start');
+
+/**
+ * temporary warning message
+ */
+if (isset($delayedWarning)) {
+    trigger_error($delayedWarning);
+}
 
 /**
  * Create Instance of xoopsSecurity Object and check super globals

--- a/htdocs/install/include/common.inc.php
+++ b/htdocs/install/include/common.inc.php
@@ -55,8 +55,11 @@ include XOOPS_INSTALL_PATH . '/class/installwizard.php';
 include_once XOOPS_ROOT_PATH . '/include/version.php';
 include_once XOOPS_INSTALL_PATH . '/include/functions.php';
 include_once XOOPS_ROOT_PATH . '/include/defines.php';
-include_once XOOPS_ROOT_PATH . '/class/xoopsload.php';
-
+//include_once XOOPS_ROOT_PATH . '/class/xoopsload.php';
+if (!class_exists('XoopsBaseConfig', false)) {
+    include_once XOOPS_ROOT_PATH . '/class/XoopsBaseConfig.php';
+    XoopsBaseConfig::bootstrapTransition();
+}
 $_SESSION['pageHasHelp'] = false;
 $_SESSION['pageHasForm'] = false;
 

--- a/htdocs/install/include/config.php
+++ b/htdocs/install/include/config.php
@@ -78,16 +78,6 @@ if (function_exists('db2_connect')) {
         'ignoredb' => array(),
     );
 }
-/* this driver is considered unstable by Doctrine and unsupported as of 2.5.0
-if (in_array('ibm', $avalable_pdo_drivers)) {
-    $configs['db_types']['pdo_ibm'] = array(
-        'desc' => 'PDO IBM Driver (untested)',
-        'type' => 'db2',
-        'params' => 'dbname,host,user,password,port',
-        'ignoredb' => array(),
-    );
-}
-*/
 if (in_array('sqlsrv', $avalable_pdo_drivers)) {
     $configs['db_types']['pdo_sqlsrv'] = array(
         'desc' => 'PDO SqlServer Driver (untested)',
@@ -107,14 +97,6 @@ if (function_exists('sqlsrv_connect')) {
 if (function_exists('mysqli_connect')) {
     $configs['db_types']['mysqli'] = array(
         'desc' => 'Mysqli Driver (untested)',
-        'type' => 'mysql',
-        'params' => 'dbname,host,user,password,port,unix_socket',
-        'ignoredb' => array('information_schema','test'),
-    );
-}
-if (in_array('mysql', $avalable_pdo_drivers)) {
-    $configs['db_types']['drizzle_pdo_mysql'] = array(
-        'desc' => 'Drizzle PDO MySql Driver (untested)',
         'type' => 'mysql',
         'params' => 'dbname,host,user,password,port,unix_socket',
         'ignoredb' => array('information_schema','test'),

--- a/htdocs/mainfile.dist.php
+++ b/htdocs/mainfile.dist.php
@@ -74,6 +74,11 @@ if (!defined("XOOPS_MAINFILE_INCLUDED")) {
     define("XOOPS_GROUP_USERS", "2");
     define("XOOPS_GROUP_ANONYMOUS", "3");
 
+    if (!class_exists('XoopsBaseConfig', false)) {
+        include __DIR__ . '/class/XoopsBaseConfig.php';
+        XoopsBaseConfig::bootstrap();
+    }
+
     if (!isset($xoopsOption["nocommon"]) && XOOPS_ROOT_PATH != "") {
         include XOOPS_ROOT_PATH."/include/common.php";
     }

--- a/htdocs/mainfile.dist.php
+++ b/htdocs/mainfile.dist.php
@@ -76,7 +76,7 @@ if (!defined("XOOPS_MAINFILE_INCLUDED")) {
 
     if (!class_exists('XoopsBaseConfig', false)) {
         include __DIR__ . '/class/XoopsBaseConfig.php';
-        XoopsBaseConfig::bootstrap();
+        XoopsBaseConfig::bootstrapTransition();
     }
 
     if (!isset($xoopsOption["nocommon"]) && XOOPS_ROOT_PATH != "") {

--- a/htdocs/xoops_lib/Xoops/Core/Yaml.php
+++ b/htdocs/xoops_lib/Xoops/Core/Yaml.php
@@ -64,7 +64,7 @@ class Yaml
      *
      * @param string $yamlString YAML dump string
      *
-     * @return mixed|bool PHP array or false on error
+     * @return array|boolean PHP array or false on error
      */
     public static function load($yamlString)
     {
@@ -82,7 +82,7 @@ class Yaml
      *
      * @param string $yamlFile filename of YAML file
      *
-     * @return mixed|bool PHP array or false on error
+     * @return array|boolean PHP array or false on error
      */
     public static function read($yamlFile)
     {
@@ -104,7 +104,7 @@ class Yaml
      * @param integer $inline   Nesting level where you switch to inline YAML
      * @param integer $indent   Number of spaces to indent for nested nodes
      *
-     * @return boolean number of bytes written, or false on error
+     * @return integer|boolean number of bytes written, or false on error
      */
     public static function save($var, $yamlFile, $inline = 4, $indent = 4)
     {
@@ -130,7 +130,7 @@ class Yaml
      * @param integer $inline Nesting level where you switch to inline YAML
      * @param integer $indent Number of spaces to indent for nested nodes
      *
-     * @return string|bool YAML string or false on error
+     * @return string|boolean YAML string or false on error
      */
     public static function dumpWrapped($var, $inline = 4, $indent = 4)
     {
@@ -154,7 +154,7 @@ class Yaml
      *
      * @param string $yamlString YAML dump string
      *
-     * @return mixed|bool PHP array or false on error
+     * @return array|boolean PHP array or false on error
      */
     public static function loadWrapped($yamlString)
     {
@@ -180,7 +180,7 @@ class Yaml
      *
      * @param string $yamlFile filename of YAML file
      *
-     * @return mixed|bool PHP array or false on error
+     * @return array|boolean PHP array or false on error
      */
     public static function readWrapped($yamlFile)
     {
@@ -207,7 +207,7 @@ class Yaml
      * @param integer $inline   Nesting level where you switch to inline YAML
      * @param integer $indent   Number of spaces to indent for nested nodes
      *
-     * @return boolean number of bytes written, or false on error
+     * @return integer|boolean number of bytes written, or false on error
      */
     public static function saveWrapped($var, $yamlFile, $inline = 4, $indent = 4)
     {

--- a/htdocs/xoops_lib/Xoops/Core/Yaml.php
+++ b/htdocs/xoops_lib/Xoops/Core/Yaml.php
@@ -117,4 +117,107 @@ class Yaml
         }
         return $ret;
     }
+
+    /**
+     * Dump an PHP array as a YAML string with a php wrapper
+     *
+     * The wrap is a php header that surrounds the yaml with section markers,
+     * '---' and '...' along with php comment markers. The php wrapper keeps the
+     * yaml file contents from being revealed by serving the file directly from
+     * a poorly configured server.
+     *
+     * @param mixed   $var    Variable which will be dumped
+     * @param integer $inline Nesting level where you switch to inline YAML
+     * @param integer $indent Number of spaces to indent for nested nodes
+     *
+     * @return string|bool YAML string or false on error
+     */
+    public static function dumpWrapped($var, $inline = 4, $indent = 4)
+    {
+        try {
+            $yamlString = VendorYaml::dump($var, $inline, $indent);
+            $ret = empty($yamlString) ? false : "<?php\n/*\n---\n" . $yamlString . "\n...\n*/\n";
+        } catch (\Exception $e) {
+            \Xoops::getInstance()->events()->triggerEvent('core.exception', $e);
+            $ret = false;
+        }
+        return $ret;
+    }
+
+    /**
+     * Load a YAML string with a php wrapper into a PHP array
+     *
+     * The wrap is a php header that surrounds the yaml with section markers,
+     * '---' and '...' along with php comment markers. The php wrapper keeps the
+     * yaml file contents from being revealed by serving the file directly from
+     * a poorly configured server.
+     *
+     * @param string $yamlString YAML dump string
+     *
+     * @return mixed|bool PHP array or false on error
+     */
+    public static function loadWrapped($yamlString)
+    {
+        try {
+            $match = array();
+            $matched = preg_match('/(---.*\.\.\.)/s', $yamlString, $match);
+            $unwrapped = $matched ? $match[1] : $yamlString;
+            $ret = VendorYaml::parse($unwrapped);
+        } catch (\Exception $e) {
+            \Xoops::getInstance()->events()->triggerEvent('core.exception', $e);
+            $ret = false;
+        }
+        return $ret;
+    }
+
+    /**
+     * Read a file containing YAML with a php wrapper into a PHP array
+     *
+     * The wrap is a php header that surrounds the yaml with section markers,
+     * '---' and '...' along with php comment markers. The php wrapper keeps the
+     * yaml file contents from being revealed by serving the file directly from
+     * a poorly configured server.
+     *
+     * @param string $yamlFile filename of YAML file
+     *
+     * @return mixed|bool PHP array or false on error
+     */
+    public static function readWrapped($yamlFile)
+    {
+        try {
+            $yamlString = file_get_contents($yamlFile);
+            $ret = self::loadWrapped($yamlString);
+        } catch (\Exception $e) {
+            \Xoops::getInstance()->events()->triggerEvent('core.exception', $e);
+            $ret = false;
+        }
+        return $ret;
+    }
+
+    /**
+     * Save a PHP array as a YAML file with a php wrapper
+     *
+     * The wrap is a php header that surrounds the yaml with section markers,
+     * '---' and '...' along with php comment markers. The php wrapper keeps the
+     * yaml file contents from being revealed by serving the file directly from
+     * a poorly configured server.
+     *
+     * @param array   $var      variable which will be dumped
+     * @param string  $yamlFile filename of YAML file
+     * @param integer $inline   Nesting level where you switch to inline YAML
+     * @param integer $indent   Number of spaces to indent for nested nodes
+     *
+     * @return boolean number of bytes written, or false on error
+     */
+    public static function saveWrapped($var, $yamlFile, $inline = 4, $indent = 4)
+    {
+        try {
+            $yamlString = self::dumpWrapped($var, $inline, $indent);
+            $ret = file_put_contents($yamlFile, $yamlString);
+        } catch (\Exception $e) {
+            \Xoops::getInstance()->events()->triggerEvent('core.exception', $e);
+            $ret = false;
+        }
+        return $ret;
+    }
 }


### PR DESCRIPTION
Groundwork for easily switching XOOPS configuration, even inside the same directory structure. This will be useful in testing, sharing code between multiple instances, and more advanced configurations.

Right now, these changes just populate the object from the defines made in mainfile and secure.