### PR TITLE
Add Xoops\Core\Request::getIP() to get an IP address

### DIFF
--- a/UnitTestXoops/xoopsLib/Xoops/Core/RequestTest.php
+++ b/UnitTestXoops/xoopsLib/Xoops/Core/RequestTest.php
@@ -262,7 +262,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Xoops\Core\Request::getIp
      */
-    public function testGetIP()
+    public function testGetIPv4()
     {
         $varname = 'RequestTest';
 
@@ -276,6 +276,13 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $default = '0.0.0.0';
         $this->assertEquals($default, Request::getIP($varname, $default));
 
+    }
+
+    /**
+     * @covers Xoops\Core\Request::getIp
+     */
+    public function testGetIPv6()
+    {
         $_REQUEST[$varname] = 'FE80:0000:0000:0000:0202:B3FF:FE1E:8329';
         $this->assertEquals($_REQUEST[$varname], Request::getIP($varname));
 

--- a/UnitTestXoops/xoopsLib/Xoops/Core/RequestTest.php
+++ b/UnitTestXoops/xoopsLib/Xoops/Core/RequestTest.php
@@ -253,6 +253,40 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $_REQUEST[$varname] = 'msdfniondfnlknlsdf';
         $this->assertEquals('', Request::getEmail($varname));
+
+        $_REQUEST[$varname] = 'msdfniondfnlknlsdf';
+        $default = 'nobody@localhost';
+        $this->assertEquals($default, Request::getEmail($varname, $default));
+    }
+
+    /**
+     * @covers Xoops\Core\Request::getIp
+     */
+    public function testGetIP()
+    {
+        $varname = 'RequestTest';
+
+        $_REQUEST[$varname] = '16.32.48.64';
+        $this->assertEquals($_REQUEST[$varname], Request::getIP($varname));
+
+        $_REQUEST[$varname] = '316.32.48.64';
+        $this->assertEquals('', Request::getIP($varname));
+
+        $_REQUEST[$varname] = '316.32.48.64';
+        $default = '0.0.0.0';
+        $this->assertEquals($default, Request::getIP($varname, $default));
+
+        $_REQUEST[$varname] = 'FE80:0000:0000:0000:0202:B3FF:FE1E:8329';
+        $this->assertEquals($_REQUEST[$varname], Request::getIP($varname));
+
+        $_REQUEST[$varname] = 'FE80::0202:B3FF:FE1E:8329';
+        $this->assertEquals($_REQUEST[$varname], Request::getIP($varname));
+
+        $_REQUEST[$varname] = 'GE80::0202:B3FF:FE1E:8329';
+        $this->assertEquals('', Request::getIP($varname));
+
+        $_REQUEST[$varname] = '::ffff:16.32.48.64';
+        $this->assertEquals($_REQUEST[$varname], Request::getIP($varname));
     }
 
     /**

--- a/UnitTestXoops/xoopsLib/Xoops/Core/RequestTest.php
+++ b/UnitTestXoops/xoopsLib/Xoops/Core/RequestTest.php
@@ -283,6 +283,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetIPv6()
     {
+        $varname = 'RequestTest';
+
         $_REQUEST[$varname] = 'FE80:0000:0000:0000:0202:B3FF:FE1E:8329';
         $this->assertEquals($_REQUEST[$varname], Request::getIP($varname));
 

--- a/htdocs/xoops_lib/Xoops/Core/FilterInput.php
+++ b/htdocs/xoops_lib/Xoops/Core/FilterInput.php
@@ -256,6 +256,15 @@ class FilterInput
                 }
                 break;
 
+            case 'IP':
+                $result = (string) $source;
+                // this may be too restrictive.
+                // Should the FILTER_FLAG_NO_PRIV_RANGE flag be excluded?
+                if (!filter_var((string) $source,  FILTER_VALIDATE_IP)) {
+                    $result = '';
+                }
+                break;
+
             default:
                 $result = $filter->process($source);
                 break;

--- a/htdocs/xoops_lib/Xoops/Core/Request.php
+++ b/htdocs/xoops_lib/Xoops/Core/Request.php
@@ -310,11 +310,27 @@ class Request
      * @param string $default Default value if the variable does not exist
      * @param string $hash    Where the var should come from (POST, GET, FILES, COOKIE, METHOD)
      *
-     * @return string email address of empty if invalid
+     * @return string email address or default if invalid
      */
     public static function getEmail($name, $default = '', $hash = 'default')
     {
-        return (string) self::getVar($name, $default, $hash, 'email');
+        $ret = (string) self::getVar($name, $default, $hash, 'email');
+        return empty($ret) ? $default : $ret;
+    }
+
+    /**
+     * Fetches and returns an IP address
+     *
+     * @param string $name    Variable name
+     * @param string $default Default value if the variable does not exist
+     * @param string $hash    Where the var should come from (POST, GET, FILES, COOKIE, METHOD)
+     *
+     * @return string IP address or default if invalid
+     */
+    public static function getIP($name, $default = '', $hash = 'default')
+    {
+        $ret = (string) self::getVar($name, $default, $hash, 'ip');
+        return empty($ret) ? $default : $ret;
     }
 
     /**


### PR DESCRIPTION
Includes backing "IP" type in FilterInput, and unit tests. Also, small change to "EMAIL" type. Both 'ip' and 'email' will now return the specified default if the input is invalid.