### PR TITLE
Excluding unit tests from scrutinizer-ci consideration

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,6 @@
+filter:
+    excluded_paths:
+        - 'UnitTestXoops/*'
 checks:
     php:
         code_rating: true


### PR DESCRIPTION
This would have been done by default if the directory was named "test."