### PR TITLE
Alert and Confirm clean up

### DIFF
--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -171,7 +171,7 @@ function xoops_confirm($hiddens, $action, $msg, $submit = '', $addtoken = true)
 {
     $xoops = Xoops::getInstance();
     $xoops->deprecated(__FUNCTION__ . ' is deprecated since XOOPS 2.6.0. See how to replace it in file ' . __FILE__ . ' line ' . __LINE__);
-    $xoops->confirm($hiddens, $action, $msg, $submit, $addtoken);
+    echo $xoops->confirm($hiddens, $action, $msg, $submit, $addtoken);
 }
 
 /**

--- a/htdocs/modules/avatars/admin/avatar_custom.php
+++ b/htdocs/modules/avatars/admin/avatar_custom.php
@@ -196,7 +196,7 @@ switch ($op) {
                     . $obj->getVar('avatar_name', 's') . '</div>'
                     . XoopsLocale::Q_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_ITEM;
                 // Display message
-                $xoops->confirm(
+                echo $xoops->confirm(
                     array('ok' => 1, 'op' => 'delete', 'avatar_id' => $avatar_id),
                     'avatar_custom.php',
                     $msg

--- a/htdocs/modules/avatars/admin/avatar_system.php
+++ b/htdocs/modules/avatars/admin/avatar_system.php
@@ -203,7 +203,7 @@ switch ($op) {
                     . $obj->getVar('avatar_name', 's') . '</div>'
                     . XoopsLocale::Q_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_ITEM;
                 // Display message
-                $xoops->confirm(
+                echo $xoops->confirm(
                     array('ok' => 1, 'op' => 'delete', 'avatar_id' => $avatar_id),
                     'avatar_system.php',
                     $msg

--- a/htdocs/modules/banners/admin/banners.php
+++ b/htdocs/modules/banners/admin/banners.php
@@ -309,7 +309,7 @@ switch ($op) {
                         $img .= "<img src='" . $imageurl . "' alt='' />";
                     }
                 }
-                $xoops->confirm(array("ok" => 1, "bid" => $bid, "op" => "delete"), 'banners.php', XoopsLocale::Q_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_ITEM . '<br \>' . $img . '<br \>');
+                echo $xoops->confirm(array("ok" => 1, "bid" => $bid, "op" => "delete"), 'banners.php', XoopsLocale::Q_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_ITEM . '<br \>' . $img . '<br \>');
             }
         } else {
             $xoops->redirect('banners.php', 1, XoopsLocale::E_DATABASE_NOT_UPDATED);

--- a/htdocs/modules/banners/admin/clients.php
+++ b/htdocs/modules/banners/admin/clients.php
@@ -190,7 +190,7 @@ switch ($op) {
                     echo $xoops->alert('error', $obj->getHtmlErrors());
                 }
             } else {
-                $xoops->confirm(
+                echo $xoops->confirm(
                     array("ok" => 1, "cid" => $cid, "op" => "delete"),
                     'clients.php',
                     sprintf(_AM_BANNERS_CLIENTS_SUREDEL, $obj->getVar("bannerclient_name")) . '<br />'

--- a/htdocs/modules/codex/cache.php
+++ b/htdocs/modules/codex/cache.php
@@ -83,7 +83,7 @@ $key = 'xmfdemo';
 echo $key . ' ' . $xmfCache->cacheRead($key, 'getSomeContent') . '<br />';
 
 echo '<h3>Alternate Caches</h3>';
-// Xoops cache() method can take a name parameter, tochoose a cache configuration.
+// Xoops cache() method can take a name parameter, to choose a cache configuration.
 // Alternate caches can be defined in var-path/configs/cache.php if needed.
 // The default cache definition is named 'default' and it will be used if no
 // name is specified to cache() or if no cache is defined for the specified name.

--- a/htdocs/modules/codex/xmf.php
+++ b/htdocs/modules/codex/xmf.php
@@ -123,17 +123,16 @@ echo '<p>' . Metagen::generateSeoTitle($title) . '</p>';
 echo '<h4>Article with Top 25 Keywords Highlighted</h4>';
 // get important words from title
 $title_keywords = Metagen::generateKeywords($title, 25, 3);
-Debug::dump($title_keywords);
+//Debug::dump($title_keywords);
 // get top 25 keywords, but always keep keywords from title
 $keywords = Metagen::generateKeywords($article, 25, 4, $title_keywords);
-Debug::dump($keywords);
+Debug::dump($keywords, true);
 echo Highlighter::apply($keywords, $article);
 
 // add to the page
 Metagen::assignTitle($title);
 Metagen::assignKeywords($keywords);
 Metagen::assignDescription($description);
-
 
 // dump our source
 echo '<br /><h2>Source code</h2>';

--- a/htdocs/modules/comments/class/helper.php
+++ b/htdocs/modules/comments/class/helper.php
@@ -896,7 +896,7 @@ class Comments extends Xoops\Module\Helper\HelperAbstract
                     if (!empty($comment_confirm_extra) && is_array($comment_confirm_extra)) {
                         $comment_confirm = $comment_confirm + $comment_confirm_extra;
                     }
-                    $xoops->confirm($comment_confirm, 'comment_delete.php', _MD_COMMENTS_DELETESELECT);
+                    echo $xoops->confirm($comment_confirm, 'comment_delete.php', _MD_COMMENTS_DELETESELECT);
                     $xoops->footer();
                     break;
             }

--- a/htdocs/modules/images/admin/categories.php
+++ b/htdocs/modules/images/admin/categories.php
@@ -132,7 +132,7 @@ switch ($op) {
                     $xoops->redirect('categories.php', 2, XoopsLocale::S_DATABASE_UPDATED);
                 }
             } else {
-                $xoops->confirm(
+                echo $xoops->confirm(
                     array('op' => 'del', 'ok' => 1, 'imgcat_id' => $imgcat_id),
                     XOOPS_URL . '/modules/images/admin/categories.php',
                     sprintf(_AM_IMAGES_CAT_DELETE, $obj->getVar('imgcat_name'))

--- a/htdocs/modules/images/admin/images.php
+++ b/htdocs/modules/images/admin/images.php
@@ -149,7 +149,7 @@ switch ($op) {
                 } else {
                     $img = XOOPS_UPLOAD_URL . '/' . $obj->getVar('image_name');
                 }
-                $xoops->confirm(
+                echo $xoops->confirm(
                     array('op' => 'del', 'ok' => 1, 'image_id' => $image_id, 'imgcat_id' => $obj->getVar('imgcat_id')),
                     XOOPS_URL . '/modules/images/admin/images.php',
                     sprintf(_AM_IMAGES_IMG_DELETE, $obj->getVar('image_nicename'))

--- a/htdocs/modules/menus/admin/admin_menu.php
+++ b/htdocs/modules/menus/admin/admin_menu.php
@@ -140,7 +140,7 @@ switch ($op) {
                 echo $xoops->alert('error', $obj->getHtmlErrors());
             }
         } else {
-            $xoops->confirm(
+            echo $xoops->confirm(
                 array('ok' => 1, 'id' => $id, 'op' => 'del', 'menu_id' => $menu_id),
                 $helper->url('admin/admin_menu.php'),
                 _AM_MENUS_MSG_SUREDEL . '<br /><strong>' . $obj->getVar('title') . '</strong>'

--- a/htdocs/modules/menus/admin/admin_menus.php
+++ b/htdocs/modules/menus/admin/admin_menus.php
@@ -99,7 +99,7 @@ switch ($op) {
                 echo $xoops->alert('error', $obj->getHtmlErrors());
             }
         } else {
-            $xoops->confirm(
+            echo $xoops->confirm(
                 array('ok' => 1, 'id' => $id, 'op' => 'del'),
                 $helper->url('admin/admin_menus.php'),
                 _AM_MENUS_MSG_SUREDEL . '<br /><strong>' . $obj->getVar('title') . '</strong>'

--- a/htdocs/modules/notifications/index.php
+++ b/htdocs/modules/notifications/index.php
@@ -165,7 +165,7 @@ switch ($op) {
             'uid' => $uid, 'delete_ok' => 1, 'del_not' => $_POST['del_not']
         );
         echo '<h4>' . _MD_NOTIFICATIONS_DELETINGNOTIFICATIONS . '</h4>';
-        $xoops->confirm($hidden_vars, $xoops->getEnv('PHP_SELF'), _MD_NOTIFICATIONS_RUSUREDEL);
+        echo $xoops->confirm($hidden_vars, $xoops->getEnv('PHP_SELF'), _MD_NOTIFICATIONS_RUSUREDEL);
         $xoops->footer();
         // FIXME: There is a problem here... in $xoops->confirm it treats arrays as
         // optional radio arguments on the confirmation page... change this or

--- a/htdocs/modules/page/admin/content.php
+++ b/htdocs/modules/page/admin/content.php
@@ -196,7 +196,7 @@ switch ($op) {
             }
         } else {
             // deleting main and secondary
-            $xoops->confirm(
+            echo $xoops->confirm(
                 array('ok' => 1, 'content_id' => $content_id, 'op' => 'delete'),
                 'content.php',
                 XoopsLocale::Q_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_ITEM

--- a/htdocs/modules/page/admin/related.php
+++ b/htdocs/modules/page/admin/related.php
@@ -168,7 +168,7 @@ switch ($op) {
                 echo $xoops->alert('error', $obj->getHtmlErrors());
             }
         } else {
-            $xoops->confirm(
+            echo $xoops->confirm(
                 array('ok' => 1, 'related_id' => $related_id, 'op' => 'delete'),
                 'related.php',
                 XoopsLocale::Q_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_ITEM

--- a/htdocs/modules/pm/templates/pm_viewpmsg.tpl
+++ b/htdocs/modules/pm/templates/pm_viewpmsg.tpl
@@ -1,5 +1,5 @@
 <h4 class="txtcenter"><{translate key='PRIVATE_MESSAGES'}></h4>
-<{if $op}>
+<{if $op|default:false}>
 <br />
 <div class="floatright txtright" style="width: 18%;">
     <{if $op == "out"}>

--- a/htdocs/modules/pm/viewpmsg.php
+++ b/htdocs/modules/pm/viewpmsg.php
@@ -43,7 +43,7 @@ if (isset($_POST['delete_messages']) && (isset($_POST['msg_id']) || isset($_POST
         $xoops->tpl()->assign('errormsg', implode('<br />', $xoops->security()->getErrors()));
     } else {
         if (empty($_REQUEST['ok'])) {
-            $xoops->confirm(array(
+            echo $xoops->confirm(array(
                                  'ok' => 1, 'delete_messages' => 1, 'op' => $_REQUEST['op'],
                                  'msg_ids' => json_encode(array_map("intval", $_POST['msg_id']))
                             ), $_SERVER['REQUEST_URI'], XoopsLocale::Q_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_MESSAGES);
@@ -121,7 +121,7 @@ if (isset($_REQUEST['empty_messages'])) {
         $xoops->tpl()->assign('errormsg', implode('<br />', $xoops->security()->getErrors()));
     } else {
         if (empty($_REQUEST['ok'])) {
-            $xoops->confirm(array(
+            echo $xoops->confirm(array(
                                  'ok' => 1, 'empty_messages' => 1, 'op' => $_REQUEST['op']
                             ), $_SERVER['REQUEST_URI'], _PM_RUSUREEMPTY);
             $xoops->footer();

--- a/htdocs/modules/profile/admin/category.php
+++ b/htdocs/modules/profile/admin/category.php
@@ -110,7 +110,7 @@ switch ($op) {
                 // Define Stylesheet
                 $xoops->theme()->addStylesheet('modules/system/css/admin.css');
                 $xoops->tpl()->assign('form', false);
-                $xoops->confirm(
+                echo $xoops->confirm(
                     array("ok" => 1, "id" => $id, "op" => "delete"),
                     'category.php',
                     sprintf(_PROFILE_AM_RUSUREDEL, $obj->getVar('cat_title')) . '<br />'

--- a/htdocs/modules/profile/admin/field.php
+++ b/htdocs/modules/profile/admin/field.php
@@ -315,7 +315,7 @@ switch ($op) {
                 // Define Stylesheet
                 $xoops->theme()->addStylesheet('modules/system/css/admin.css');
                 $xoops->tpl()->assign('form', false);
-                $xoops->confirm(
+                echo $xoops->confirm(
                     array("ok" => 1, "id" => $id, "op" => "delete"),
                     'field.php',
                     sprintf(_PROFILE_AM_RUSUREDEL, $obj->getVar('field_title')) . '<br />'

--- a/htdocs/modules/profile/admin/step.php
+++ b/htdocs/modules/profile/admin/step.php
@@ -110,7 +110,7 @@ switch ($op) {
                 // Define Stylesheet
                 $xoops->theme()->addStylesheet('modules/system/css/admin.css');
                 $xoops->tpl()->assign('form', false);
-                $xoops->confirm(
+                echo $xoops->confirm(
                     array("ok" => 1, "id" => $id, "op" => "delete"),
                     'step.php',
                     sprintf(_PROFILE_AM_RUSUREDEL, $obj->getVar('step_name')) . '<br />'

--- a/htdocs/modules/profile/admin/user.php
+++ b/htdocs/modules/profile/admin/user.php
@@ -231,7 +231,7 @@ switch ($op) {
             }
 
         } else {
-            $xoops->confirm(
+            echo $xoops->confirm(
                 array('ok' => 1, 'id' => $_REQUEST['id'], 'op' => 'delete'),
                 $_SERVER['REQUEST_URI'],
                 sprintf(_PROFILE_AM_RUSUREDEL, $obj->getVar('uname') . " (" . $obj->getVar('email') . ")")

--- a/htdocs/modules/profile/index.php
+++ b/htdocs/modules/profile/index.php
@@ -106,7 +106,7 @@ if ($op == 'delete') {
         $ok = !isset($_POST['ok']) ? 0 : intval($_POST['ok']);
         if ($ok != 1) {
             $xoops->header();
-            $xoops->confirm(
+            echo $xoops->confirm(
                 array('op' => 'delete', 'ok' => 1),
                 'user.php',
                 XoopsLocale::Q_ARE_YOU_SURE_TO_DELETE_ACCOUNT . '<br/>' . XoopsLocale::THIS_WILL_REMOVE_ALL_YOUR_INFO

--- a/htdocs/modules/profile/user.php
+++ b/htdocs/modules/profile/user.php
@@ -110,7 +110,7 @@ if ($op == 'delete') {
         $ok = !isset($_POST['ok']) ? 0 : intval($_POST['ok']);
         if ($ok != 1) {
             include __DIR__ . DIRECTORY_SEPARATOR . 'header.php';
-            $xoops->confirm(array('op' => 'delete', 'ok' => 1), 'user.php', XoopsLocale::Q_ARE_YOU_SURE_TO_DELETE_ACCOUNT . '<br/>' . XoopsLocale::THIS_WILL_REMOVE_ALL_YOUR_INFO);
+            echo $xoops->confirm(array('op' => 'delete', 'ok' => 1), 'user.php', XoopsLocale::Q_ARE_YOU_SURE_TO_DELETE_ACCOUNT . '<br/>' . XoopsLocale::THIS_WILL_REMOVE_ALL_YOUR_INFO);
             include __DIR__ . DIRECTORY_SEPARATOR . 'footer.php';
         } else {
             $del_uid = $xoops->user->getVar("uid");

--- a/htdocs/modules/publisher/admin/category.php
+++ b/htdocs/modules/publisher/admin/category.php
@@ -49,7 +49,7 @@ switch ($op) {
             $xoops->redirect("category.php", 1, sprintf(_AM_PUBLISHER_COLISDELETED, $name));
         } else {
             $xoops->header();
-            $xoops->confirm(array('op' => 'del', 'categoryid' => $categoryObj->getVar('categoryid'), 'confirm' => 1, 'name' => $categoryObj->getVar('name')), 'category.php', _AM_PUBLISHER_DELETECOL . " '" . $categoryObj->getVar('name') . "'. <br /> <br />" . _AM_PUBLISHER_DELETE_CAT_CONFIRM, _AM_PUBLISHER_DELETE);
+            echo $xoops->confirm(array('op' => 'del', 'categoryid' => $categoryObj->getVar('categoryid'), 'confirm' => 1, 'name' => $categoryObj->getVar('name')), 'category.php', _AM_PUBLISHER_DELETECOL . " '" . $categoryObj->getVar('name') . "'. <br /> <br />" . _AM_PUBLISHER_DELETE_CAT_CONFIRM, _AM_PUBLISHER_DELETE);
             $xoops->footer();
         }
         break;

--- a/htdocs/modules/publisher/admin/file.php
+++ b/htdocs/modules/publisher/admin/file.php
@@ -143,7 +143,7 @@ switch ($op) {
             $fileid = isset($_GET['fileid']) ? intval($_GET['fileid']) : 0;
 
             PublisherUtils::cpHeader();
-            $xoops->confirm(array('op' => 'del', 'fileid' => $fileObj->getVar('fileid'), 'confirm' => 1, 'name' => $fileObj->getVar('name')), 'file.php', _AM_PUBLISHER_DELETETHISFILE . " <br />" . $fileObj->getVar('name') . " <br /> <br />", _AM_PUBLISHER_DELETE);
+            echo $xoops->confirm(array('op' => 'del', 'fileid' => $fileObj->getVar('fileid'), 'confirm' => 1, 'name' => $fileObj->getVar('name')), 'file.php', _AM_PUBLISHER_DELETETHISFILE . " <br />" . $fileObj->getVar('name') . " <br /> <br />", _AM_PUBLISHER_DELETE);
             $xoops->footer();
         }
         exit();

--- a/htdocs/modules/publisher/admin/item.php
+++ b/htdocs/modules/publisher/admin/item.php
@@ -159,7 +159,7 @@ switch ($op) {
             $xoops->redirect("item.php", 2, sprintf(_AM_PUBLISHER_ITEMISDELETED, $itemObj->title()));
         } else {
             $xoops->header();
-            $xoops->confirm(array(
+            echo $xoops->confirm(array(
                 'op' => 'del', 'itemid' => $itemObj->getVar('itemid'), 'confirm' => 1, 'name' => $itemObj->title()
             ), 'item.php', _AM_PUBLISHER_DELETETHISITEM . " <br />'" . $itemObj->title() . "'. <br /> <br />", _AM_PUBLISHER_DELETE);
             $xoops->footer();

--- a/htdocs/modules/publisher/admin/pw_delete_file.php
+++ b/htdocs/modules/publisher/admin/pw_delete_file.php
@@ -27,6 +27,6 @@ if (isset($_POST["op"]) && ($_POST["op"] == "delfileok")) {
     $xoops->redirect($_POST['backto'], 2, _AM_PUBLISHER_FDELETED);
 } else {
     $xoops->header();
-    $xoops->confirm(array('backto' => $_POST['backto'], 'address' => $_POST["address"], 'op' => 'delfileok'), 'pw_delete_file.php', _AM_PUBLISHER_RUSUREDELF, XoopsLocale::YES);
+    echo $xoops->confirm(array('backto' => $_POST['backto'], 'address' => $_POST["address"], 'op' => 'delfileok'), 'pw_delete_file.php', _AM_PUBLISHER_RUSUREDELF, XoopsLocale::YES);
     $xoops->footer();
 }

--- a/htdocs/modules/publisher/file.php
+++ b/htdocs/modules/publisher/file.php
@@ -108,7 +108,7 @@ switch ($op) {
         } else {
             // no confirm: show deletion condition
             $xoops->header();
-            $xoops->confirm(array(
+            echo $xoops->confirm(array(
                 'op' => 'del', 'fileid' => $fileObj->getVar('fileid'), 'confirm' => 1,
                 'name' => $fileObj->getVar('name')
             ), 'file.php', _AM_PUBLISHER_DELETETHISFILE . " <br />" . $fileObj->getVar('name') . " <br /> <br />", _AM_PUBLISHER_DELETE);

--- a/htdocs/modules/publisher/submit.php
+++ b/htdocs/modules/publisher/submit.php
@@ -117,7 +117,7 @@ switch ($op) {
             $xoops->redirect("index.php", 2, sprintf(_AM_PUBLISHER_ITEMISDELETED, $itemObj->title()));
         } else {
             $xoops->header();
-            $xoops->confirm(array('op' => 'del', 'itemid' => $itemObj->getVar('itemid'), 'confirm' => 1, 'name' => $itemObj->title()), 'submit.php', _AM_PUBLISHER_DELETETHISITEM . " <br />'" . $itemObj->title() . "'. <br /> <br />", _AM_PUBLISHER_DELETE);
+            echo $xoops->confirm(array('op' => 'del', 'itemid' => $itemObj->getVar('itemid'), 'confirm' => 1, 'name' => $itemObj->title()), 'submit.php', _AM_PUBLISHER_DELETETHISITEM . " <br />'" . $itemObj->title() . "'. <br /> <br />", _AM_PUBLISHER_DELETE);
             $xoops->footer();
         }
         break;

--- a/htdocs/modules/smilies/admin/smilies.php
+++ b/htdocs/modules/smilies/admin/smilies.php
@@ -154,7 +154,7 @@ switch ($op) {
             }
         } else {
             $smilies_img = ($obj->getVar('smiley_url')) ? $obj->getVar('smiley_url') : 'blank.gif';
-            $xoops->confirm(array(
+            echo $xoops->confirm(array(
                                  'ok' => 1, 'smiley_id' => $smiley_id, 'op' => 'del'
                             ), XOOPS_URL . '/modules/smilies/admin/smilies.php', sprintf(_AM_SMILIES_SUREDEL) . '<br /><strong>' . $obj->getVar('smiley_emotion') . '</strong><br /><img src="' . XOOPS_UPLOAD_URL . '/' . $smilies_img . '" alt="' . $obj->getVar('smiley_emotion') . '"><br />');
         }

--- a/htdocs/modules/system/admin/blocksadmin/main.php
+++ b/htdocs/modules/system/admin/blocksadmin/main.php
@@ -467,7 +467,7 @@ switch ($op) {
             // Call Header
             $xoops->header('admin:system/system_header.tpl');
             // Display Question
-            $xoops->confirm(array(
+            echo $xoops->confirm(array(
                 'op'  => 'delete_ok',
                 'fct' => 'blocksadmin',
                 'bid' => $block->getVar('bid')

--- a/htdocs/modules/system/admin/groups/main.php
+++ b/htdocs/modules/system/admin/groups/main.php
@@ -342,7 +342,7 @@ switch ($op) {
                 $system_breadcrumb->addHelp(system_adminVersion('groups', 'help') . '#edit');
                 $system_breadcrumb->render();
                 // Display message
-                $xoops->confirm(
+                echo $xoops->confirm(
                     array(
                         "ok" => 1,
                         "groups_id" => $_REQUEST["groups_id"],

--- a/htdocs/modules/system/admin/users/main.php
+++ b/htdocs/modules/system/admin/users/main.php
@@ -120,7 +120,7 @@ switch ($op) {
             $system_breadcrumb->addHelp(system_adminVersion('users', 'help') . '#delete');
             $system_breadcrumb->addLink(SystemLocale::DELETE_USER);
             $system_breadcrumb->render();
-            $xoops->confirm(array(
+            echo $xoops->confirm(array(
                 'ok' => 1, 'uid' => $uid, 'op' => 'users_delete'
             ), "admin.php?fct=users", sprintf(SystemLocale::F_DELETE_USER, $user->getVar('uname')) . '<br />');
         }

--- a/htdocs/modules/system/templates/system_alert.tpl
+++ b/htdocs/modules/system/templates/system_alert.tpl
@@ -1,6 +1,6 @@
 <div class="alert alert-block <{$alert_type}>">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
-    <{if $alert_title}>
+    <{if $alert_title|default:false}>
     <h4><{$alert_title}></h4>
     <{/if}>
     <{$alert_msg}>

--- a/htdocs/modules/system/templates/system_confirm.tpl
+++ b/htdocs/modules/system/templates/system_confirm.tpl
@@ -3,7 +3,7 @@
     <br />
     <form name="confirm" id="confirm" action="<{$action}>" method="post">
         <{$hiddens}>
-        <{$token}>
+        <{$token|default:''}>
         <input class="btn btn-danger" type="submit" name="confirm_submit" value="<{$submit}>" title="<{$submit}>">
         <input class="btn" type="button" name="confirm_back" value="<{translate key='A_CANCEL'}>" onclick="javascript:history.go(-1);" title="<{translate key='A_CANCEL'}>">
 

--- a/htdocs/modules/userrank/admin/userrank.php
+++ b/htdocs/modules/userrank/admin/userrank.php
@@ -170,7 +170,7 @@ switch ($op) {
             }
         } else {
             $rank_img = ($obj->getVar("rank_image")) ? $obj->getVar("rank_image") : 'blank.gif';
-            $xoops->confirm(array(
+            echo $xoops->confirm(array(
                 "ok" => 1, "rank_id" => $_REQUEST["rank_id"], "op" => "userrank_delete"
             ), $_SERVER["REQUEST_URI"], sprintf(_AM_USERRANK_SUREDEL) . '<br \><img src="' . XOOPS_UPLOAD_URL . '/' . $rank_img . '" alt="" /><br \>');
         }

--- a/htdocs/modules/xlanguage/admin/index.php
+++ b/htdocs/modules/xlanguage/admin/index.php
@@ -76,12 +76,10 @@ switch ($op) {
                     $helper->getHandlerLanguage()->createConfig();
                     $xoops->redirect('index.php', 2, _AM_XLANGUAGE_DELETED);
                 } else {
-                    ob_start();
-                    $xoops->confirm(array(
+                    $confirm = $xoops->confirm(array(
                         'ok' => 1, 'xlanguage_id' => $xlanguage_id, 'op' => 'del'
                     ), $_SERVER['REQUEST_URI'], sprintf(_AM_XLANGUAGE_DELETE_CFM . "<br /><b><span style='color : Red'> %s </span></b><br /><br />", $lang->getVar('xlanguage_name')));
-                    $confirm = '<div class="confirm">' . ob_get_contents() . '</div>';
-                    ob_end_clean();
+                    $confirm = '<div class="confirm">' . $confirm . '</div>';
                     $admin_page->addInfoBox(_MI_XLANGUAGE_DELETE);
                     $admin_page->addInfoBoxLine($confirm);
                     $admin_page->displayIndex();

--- a/htdocs/readpmsg.php
+++ b/htdocs/readpmsg.php
@@ -95,7 +95,7 @@ switch ($op) {
             }
         } else {
             $xoops->tpl()->assign('subject', $obj->getVar("subject"));
-            $xoops->confirm(array("ok" => 1, "msg_id" => $id, "op" => "delete"), 'readpmsg.php', XoopsLocale::Q_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_MESSAGES . '<br />' . $obj->getVar("subject"));
+            echo $xoops->confirm(array("ok" => 1, "msg_id" => $id, "op" => "delete"), 'readpmsg.php', XoopsLocale::Q_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_MESSAGES . '<br />' . $obj->getVar("subject"));
         }
         break;
 }

--- a/htdocs/user.php
+++ b/htdocs/user.php
@@ -134,7 +134,7 @@ if ($op == 'delete') {
         $ok = !isset($clean_input['ok']) ? 0 : $clean_input['ok'];
         if ($ok != 1) {
             $xoops->header();
-            $xoops->confirm(
+            echo $xoops->confirm(
                 array('op' => 'delete', 'ok' => 1),
                 'user.php',
                 XoopsLocale::Q_ARE_YOU_SURE_TO_DELETE_ACCOUNT . '<br/>' . XoopsLocale::THIS_WILL_REMOVE_ALL_YOUR_INFO

--- a/htdocs/viewpmsg.php
+++ b/htdocs/viewpmsg.php
@@ -39,7 +39,7 @@ if (!$xoops->isUser()) {
                 $xoops->header('module:system/system_viewpmsg.tpl');
                 // Define Stylesheet
                 $xoops->theme()->addStylesheet('modules/system/css/admin.css');
-                $xoops->confirm(array(
+                echo $xoops->confirm(array(
                         'ok' => 1, 'delete_messages' => 1,
                         'msg_ids' => json_encode(array_map("intval", $_POST['msg_id']))
                     ), $_SERVER['REQUEST_URI'], XoopsLocale::Q_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_MESSAGES);

--- a/htdocs/xoops_lib/Xmf/Debug.php
+++ b/htdocs/xoops_lib/Xmf/Debug.php
@@ -96,7 +96,7 @@ class Debug
     {
         $events = \Xoops::getInstance()->events();
         $eventName = 'debug.log';
-        if ($html && $events->hasListeners($eventName)) {
+        if (!$inline && $events->hasListeners($eventName)) {
             $events->triggerEvent($eventName, debug_backtrace());
         } else {
             return self::dump(debug_backtrace(), $inline);

--- a/htdocs/xoops_lib/Xmf/Debug.php
+++ b/htdocs/xoops_lib/Xmf/Debug.php
@@ -55,18 +55,17 @@ class Debug
     /**
      * Dump a variable
      *
-     * @param mixed $var  variable which will be dumped
-     * @param bool  $echo echo
-     * @param bool  $html dump as html
-     * @param bool  $exit exit after dump if true
+     * @param mixed $var    variable which will be dumped
+     * @param bool  $inline force inline display if true, otherwise will attempt to
+     *                      use debug.log event
      *
-     * @return mixed|string
+     * @return void
      */
-    public static function dump($var, $echo = true, $html = true, $exit = false)
+    public static function dump($var, $inline = false)
     {
         $events = \Xoops::getInstance()->events();
         $eventName = 'debug.log';
-        if ($html && $echo && $events->hasListeners($eventName)) {
+        if (!$inline && $events->hasListeners($eventName)) {
             $events->triggerEvent($eventName, $var);
             //\Kint::dump(func_get_arg(0));
         } else {
@@ -79,41 +78,28 @@ class Debug
                     'sort_arrays' => false,
                     ),
                 );
-            if (!$html) {
-                $msg = var_export($var, true);
-            } else {
-                \krumo::setConfig($config);
-                $msg = \krumo::dump($var);
-            }
-            if (!$echo) {
-                return $msg;
-            }
+            \krumo::setConfig($config);
+            $msg = \krumo::dump($var);
             echo $msg;
         }
-        if ($exit) {
-            die();
-        }
-
-        return false;
     }
 
     /**
      * Display debug backtrace
      *
-     * @param bool $echo echo
-     * @param bool $html dump as html
-     * @param bool $exit exit after dump if true
+     * @param boolean $inline force inline display if true, otherwise will attempt to
+     *                        use debug.log event
      *
      * @return mixed|string
      */
-    public static function backtrace($echo = true, $html = true, $exit = false)
+    public static function backtrace($inline = false)
     {
         $events = \Xoops::getInstance()->events();
         $eventName = 'debug.log';
         if ($html && $events->hasListeners($eventName)) {
             $events->triggerEvent($eventName, debug_backtrace());
         } else {
-            return self::dump(debug_backtrace(), $echo, $html, $exit);
+            return self::dump(debug_backtrace(), $inline);
         }
     }
 

--- a/htdocs/xoops_lib/Xmf/Metagen.php
+++ b/htdocs/xoops_lib/Xmf/Metagen.php
@@ -221,12 +221,12 @@ class Metagen
     /**
      * generateMetaTags - generate and assign all meta tags
      *
-     * @param string $title     title
-     * @param string $body      body text
-     * @param int    $count     maximum keywords to use
-     * @param int    $minLength minimum length of word to consider as keyword
-     * @param int    $wordCount maximum word count for description summary
-     * @param array  $forceKeys associative array of keywords to force use
+     * @param string        $title     title
+     * @param string        $body      body text
+     * @param int           $count     maximum keywords to use
+     * @param int           $minLength minimum length of word to consider as keyword
+     * @param int           $wordCount maximum word count for description summary
+     * @param string[]|null $forceKeys associative array of keywords to force use
      *
      * @return void
      */

--- a/htdocs/xoops_lib/Xmf/Metagen.php
+++ b/htdocs/xoops_lib/Xmf/Metagen.php
@@ -102,10 +102,10 @@ class Metagen
     /**
      * generateKeywords builds a set of keywords from text body
      *
-     * @param string       $body      text to extract keywords from
-     * @param integer      $count     number of keywords to use
-     * @param integer      $minLength minimum length of word to consider as a keyword
-     * @param string[]null $forceKeys array of keywords to force use, or null for none
+     * @param string        $body      text to extract keywords from
+     * @param integer       $count     number of keywords to use
+     * @param integer       $minLength minimum length of word to consider as a keyword
+     * @param string[]|null $forceKeys array of keywords to force use, or null for none
      *
      * @return array of keywords
      */
@@ -264,7 +264,7 @@ class Metagen
      * Create a title for the short_url field of an article
      *
      * @param string $title     title of the article
-     * @param bool   $extension extension to add
+     * @param string $extension extension to add
      *
      * @return string sort_url for the article
      *

--- a/htdocs/xoops_lib/Xmf/Module/Helper/AbstractHelper.php
+++ b/htdocs/xoops_lib/Xmf/Module/Helper/AbstractHelper.php
@@ -68,7 +68,7 @@ abstract class AbstractHelper
             // dirname specified, get a module object
             $helper = Helper::getHelper($module);
             if ($helper) {
-                $this->$module = $helper->getModule();
+                $this->module = $helper->getModule();
             }
         } else {
             // assume a passed object is appropriate

--- a/htdocs/xoops_lib/Xmf/Template/Breadcrumb.php
+++ b/htdocs/xoops_lib/Xmf/Template/Breadcrumb.php
@@ -29,7 +29,7 @@ class Breadcrumb extends AbstractTemplate
     /**
      * @var array
      */
-    private $_items = array();
+    private $items = array();
 
     /**
      * initialization run by parent::__construct
@@ -53,7 +53,7 @@ class Breadcrumb extends AbstractTemplate
      */
     public function setItems($items)
     {
-        $this->_items = $items;
+        $this->items = $items;
     }
 
     /**
@@ -63,6 +63,6 @@ class Breadcrumb extends AbstractTemplate
      */
     protected function render()
     {
-        $this->tpl->assign('xmf_breadcrumb_items', $this->_items);
+        $this->tpl->assign('xmf_breadcrumb_items', $this->items);
     }
 }

--- a/htdocs/xoops_lib/Xmf/Template/PrintContent.php
+++ b/htdocs/xoops_lib/Xmf/Template/PrintContent.php
@@ -29,27 +29,27 @@ class PrintContent extends AbstractTemplate
     /**
      * @var string
      */
-    private $_title = '';
+    private $title = '';
 
     /**
      * @var string
      */
-    private $_description = '';
+    private $description = '';
 
     /**
      * @var string
      */
-    private $_content = '';
+    private $content = '';
 
     /**
      * @var bool
      */
-    private $_pagetitle = false;
+    private $pagetitle = false;
 
     /**
      * @var int
      */
-    private $_width = 680;
+    private $width = 680;
 
     /**
      * init - called by parent::_construct
@@ -68,11 +68,11 @@ class PrintContent extends AbstractTemplate
      */
     protected function render()
     {
-        $this->tpl->assign('xmf_print_pageTitle', $this->_pagetitle ? $this->_pagetitle : $this->_title);
-        $this->tpl->assign('xmf_print_title', $this->_title);
-        $this->tpl->assign('xmf_print_description', $this->_description);
-        $this->tpl->assign('xmf_print_content', $this->_content);
-        $this->tpl->assign('xmf_print_width', $this->_width);
+        $this->tpl->assign('xmf_print_pageTitle', $this->pagetitle ? $this->pagetitle : $this->title);
+        $this->tpl->assign('xmf_print_title', $this->title);
+        $this->tpl->assign('xmf_print_description', $this->description);
+        $this->tpl->assign('xmf_print_content', $this->content);
+        $this->tpl->assign('xmf_print_width', $this->width);
     }
 
     /**
@@ -84,7 +84,7 @@ class PrintContent extends AbstractTemplate
      */
     public function setContent($content)
     {
-        $this->_content = $content;
+        $this->content = $content;
     }
 
     /**
@@ -94,7 +94,7 @@ class PrintContent extends AbstractTemplate
      */
     public function getContent()
     {
-        return $this->_content;
+        return $this->content;
     }
 
     /**
@@ -106,7 +106,7 @@ class PrintContent extends AbstractTemplate
      */
     public function setDescription($description)
     {
-        $this->_description = $description;
+        $this->description = $description;
     }
 
     /**
@@ -116,7 +116,7 @@ class PrintContent extends AbstractTemplate
      */
     public function getDescription()
     {
-        return $this->_description;
+        return $this->description;
     }
 
     /**
@@ -128,7 +128,7 @@ class PrintContent extends AbstractTemplate
      */
     public function setPagetitle($pagetitle)
     {
-        $this->_pagetitle = $pagetitle;
+        $this->pagetitle = $pagetitle;
     }
 
     /**
@@ -138,7 +138,7 @@ class PrintContent extends AbstractTemplate
      */
     public function getPagetitle()
     {
-        return $this->_pagetitle;
+        return $this->pagetitle;
     }
 
     /**
@@ -150,7 +150,7 @@ class PrintContent extends AbstractTemplate
      */
     public function setTitle($title)
     {
-        $this->_title = $title;
+        $this->title = $title;
     }
 
     /**
@@ -160,7 +160,7 @@ class PrintContent extends AbstractTemplate
      */
     public function getTitle()
     {
-        return $this->_title;
+        return $this->title;
     }
 
     /**
@@ -172,7 +172,7 @@ class PrintContent extends AbstractTemplate
      */
     public function setWidth($width)
     {
-        $this->_width = $width;
+        $this->width = $width;
     }
 
     /**
@@ -182,7 +182,6 @@ class PrintContent extends AbstractTemplate
      */
     public function getWidth()
     {
-        return $this->_width;
+        return $this->width;
     }
-
 }

--- a/htdocs/xoops_lib/Xoops.php
+++ b/htdocs/xoops_lib/Xoops.php
@@ -1185,32 +1185,33 @@ class Xoops
      */
     public function alert($type, $msg, $title = '/')
     {
+        $tpl = new \XoopsTpl();
         $alert_msg = '';
         switch ($type) {
             case 'info':
             default:
-                $this->tpl()->assign('alert_type', 'alert-info');
+                $tpl->assign('alert_type', 'alert-info');
                 if ($title == '/') {
                     $title = XoopsLocale::INFORMATION;
                 }
                 break;
 
             case 'error':
-                $this->tpl()->assign('alert_type', 'alert-error');
+                $tpl->assign('alert_type', 'alert-error');
                 if ($title == '/') {
                     $title = XoopsLocale::ERROR;
                 }
                 break;
 
             case 'success':
-                $this->tpl()->assign('alert_type', 'alert-success');
+                $tpl->assign('alert_type', 'alert-success');
                 if ($title == '/') {
                     $title = XoopsLocale::SUCCESS;
                 }
                 break;
 
             case 'warning':
-                $this->tpl()->assign('alert_type', '');
+                $tpl->assign('alert_type', '');
                 if ($title == '/') {
                     $title = XoopsLocale::WARNING;
                 }
@@ -1218,7 +1219,7 @@ class Xoops
         }
 
         if ($title != '') {
-            $this->tpl()->assign('alert_title', $title);
+            $tpl->assign('alert_title', $title);
         }
         if (!is_scalar($msg) && !is_array($msg)) {
             $msg = ''; // don't know what to do with this, so make it blank
@@ -1232,8 +1233,8 @@ class Xoops
         if ($alert_msg == '') {
             return '';
         } else {
-            $this->tpl()->assign('alert_msg', $alert_msg);
-            $ret = $this->tpl()->fetch('module:system/system_alert.tpl');
+            $tpl->assign('alert_msg', $alert_msg);
+            $ret = $tpl->fetch('module:system/system_alert.tpl');
             return $ret;
         }
     }
@@ -1273,10 +1274,11 @@ class Xoops
      */
     public function confirm($hiddens, $action, $msg, $submit = '', $addtoken = true)
     {
+        $tpl = new \XoopsTpl();
         $submit = ($submit != '') ? trim($submit) : XoopsLocale::A_SUBMIT;
-        $this->tpl()->assign('msg', $msg);
-        $this->tpl()->assign('action', $action);
-        $this->tpl()->assign('submit', $submit);
+        $tpl->assign('msg', $msg);
+        $tpl->assign('action', $action);
+        $tpl->assign('submit', $submit);
         $str_hiddens = '';
         foreach ($hiddens as $name => $value) {
             if (is_array($value)) {
@@ -1289,10 +1291,10 @@ class Xoops
             }
         }
         if ($addtoken != false) {
-            $this->tpl()->assign('token', $this->security()->getTokenHTML());
+            $tpl->assign('token', $this->security()->getTokenHTML());
         }
-        $this->tpl()->assign('hiddens', $str_hiddens);
-        $this->tpl()->display('module:system/system_confirm.tpl');
+        $tpl->assign('hiddens', $str_hiddens);
+        $tpl->display('module:system/system_confirm.tpl');
     }
 
     /**

--- a/htdocs/xoops_lib/Xoops.php
+++ b/htdocs/xoops_lib/Xoops.php
@@ -1240,37 +1240,15 @@ class Xoops
     }
 
     /**
-     * @param string  $msg
-     * @param string $title
+     * Render a confirmation form to a string
      *
-     * @return void
-     */
-    public function error($msg, $title = '')
-    {
-        $this->deprecated(__CLASS__ . "->" . __FUNCTION__ . "() is deprecated since 2.6.0. Please use " . __CLASS__ . "->alert()");
-        echo $this->alert('error', $msg, $title);
-    }
-
-    /**
-     * @param string  $msg
-     * @param string $title
+     * @param array   $hiddens  associative array of values used to complete confirmed action
+     * @param string  $action   form action (URL)
+     * @param string  $msg      message to display
+     * @param string  $submit   submit button message
+     * @param boolean $addtoken true to add CSRF token
      *
-     * @return void
-     */
-    public function result($msg, $title = '')
-    {
-        $this->deprecated(__CLASS__ . "->" . __FUNCTION__ . "() is deprecated since 2.6.0. Please use " . __CLASS__ . "->alert()");
-        echo $this->alert('info', $msg, $title);
-    }
-
-    /**
-     * @param mixed  $hiddens
-     * @param mixed  $action
-     * @param mixed  $msg
-     * @param string $submit
-     * @param bool   $addtoken
-     *
-     * @return void
+     * @return string rendered confirm message
      */
     public function confirm($hiddens, $action, $msg, $submit = '', $addtoken = true)
     {
@@ -1294,7 +1272,7 @@ class Xoops
             $tpl->assign('token', $this->security()->getTokenHTML());
         }
         $tpl->assign('hiddens', $str_hiddens);
-        $tpl->display('module:system/system_confirm.tpl');
+        return $tpl->fetch('module:system/system_confirm.tpl');
     }
 
     /**

--- a/htdocs/xoops_lib/Xoops/Core/FilterInput.php
+++ b/htdocs/xoops_lib/Xoops/Core/FilterInput.php
@@ -157,9 +157,9 @@ class FilterInput
      * specified bad code.
      *
      * @param mixed  $source Input string/array-of-string to be 'cleaned'
-     * @param string $type   Return type for the variable (INT, FLOAT,
-     *                       BOOLEAN, WORD, ALNUM, CMD, BASE64, STRING,
-     *                       ARRAY, PATH, NONE)
+     * @param string $type   Return/cleaning type for the variable, one of
+     *                       (INTEGER, FLOAT, BOOLEAN, WORD, ALNUM, CMD, BASE64,
+     *                        STRING, ARRAY, PATH, USERNAME, WEBURL, EMAIL, IP)
      *
      * @return mixed 'Cleaned' version of input parameter
      * @static

--- a/htdocs/xoops_lib/Xoops/Html/Attributes.php
+++ b/htdocs/xoops_lib/Xoops/Html/Attributes.php
@@ -13,7 +13,7 @@
 namespace Xoops\Html;
 
 /**
- * Attributes - Abstract base class for HTML attributes
+ * Attributes - Base class for HTML attributes
  *
  * @category  Xoops\Html\Attributes
  * @package   Xoops\Html

--- a/tests/unit/xoopsLib/Xoops/Html/AttributesTest.php
+++ b/tests/unit/xoopsLib/Xoops/Html/AttributesTest.php
@@ -1,0 +1,118 @@
+<?php
+namespace Xoops\Html;
+
+require_once(dirname(__FILE__).'/../../../init_mini.php');
+
+/**
+ * PHPUnit special settings :
+ * @backupGlobals disabled
+ * @backupStaticAttributes disabled
+ */
+class AttributesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Attributes
+     */
+    protected $object;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->object = new Attributes;
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+    }
+
+    /**
+     * @covers Xoops\Html\Attributes::setAttribute
+     * @todo   Implement testSetAttribute().
+     */
+    public function testSetAttribute()
+    {
+        // Remove the following lines when you implement this test.
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+    }
+
+    /**
+     * @covers Xoops\Html\Attributes::unsetAttribute
+     * @todo   Implement testUnsetAttribute().
+     */
+    public function testUnsetAttribute()
+    {
+        // Remove the following lines when you implement this test.
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+    }
+
+    /**
+     * @covers Xoops\Html\Attributes::setAttributes
+     * @todo   Implement testSetAttributes().
+     */
+    public function testSetAttributes()
+    {
+        // Remove the following lines when you implement this test.
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+    }
+
+    /**
+     * @covers Xoops\Html\Attributes::getAttribute
+     * @todo   Implement testGetAttribute().
+     */
+    public function testGetAttribute()
+    {
+        // Remove the following lines when you implement this test.
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+    }
+
+    /**
+     * @covers Xoops\Html\Attributes::hasAttribute
+     * @todo   Implement testHasAttribute().
+     */
+    public function testHasAttribute()
+    {
+        // Remove the following lines when you implement this test.
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+    }
+
+    /**
+     * @covers Xoops\Html\Attributes::addAttribute
+     * @todo   Implement testAddAttribute().
+     */
+    public function testAddAttribute()
+    {
+        // Remove the following lines when you implement this test.
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+    }
+
+    /**
+     * @covers Xoops\Html\Attributes::renderAttributeString
+     * @todo   Implement testRenderAttributeString().
+     */
+    public function testRenderAttributeString()
+    {
+        // Remove the following lines when you implement this test.
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+    }
+}

--- a/tests/unit/xoopsLib/Xoops/Html/ImgTest.php
+++ b/tests/unit/xoopsLib/Xoops/Html/ImgTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace Xoops\Html;
+
+require_once(dirname(__FILE__).'/../../../init_mini.php');
+
+/**
+ * PHPUnit special settings :
+ * @backupGlobals disabled
+ * @backupStaticAttributes disabled
+ */
+class ImgTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Img
+     */
+    protected $object;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->object = new Img(array('src' => 'image.png', 'class' => 'image'));
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+    }
+
+    /**
+     * @covers Xoops\Html\Img::__construct
+     */
+    public function test__construct()
+    {
+        $object = new Img(array('src' => 'image.png'));
+        $this->assertInstanceOf('\Xoops\Html\Attributes', $object);
+        $this->assertEquals('image.png', $object->getAttribute('src'));
+    }
+
+    /**
+     * @covers Xoops\Html\Img::render
+     * @todo   Implement testRender().
+     */
+    public function testRender()
+    {
+        $output = $this->object->render();
+        $this->assertStringStartsWith('<img ', $output);
+        $this->assertStringEndsWith(' />', $output);
+        $this->assertGreaterThanOrEqual(4, strpos($output, 'src="image.png" '));
+        $this->assertGreaterThanOrEqual(4, strpos($output, 'class="image" '));
+    }
+}

--- a/tests/unit/xoopsLib/XoopsTest.php
+++ b/tests/unit/xoopsLib/XoopsTest.php
@@ -712,51 +712,20 @@ class XoopsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_string($value));
     }
 
-    public function test_error()
-	{
-        $instance = Xoops::getInstance();
-
-        ob_start();
-        $instance->error('test');
-        $value = ob_get_contents();
-        ob_end_clean();
-        $this->assertTrue(is_string($value));
-    }
-
-    public function test_result()
-	{
-        $instance = Xoops::getInstance();
-
-        ob_start();
-        $instance->result('test');
-        $value = ob_get_contents();
-        ob_end_clean();
-        $this->assertTrue(is_string($value));
-    }
-
     public function test_confirm()
 	{
         $instance = Xoops::getInstance();
 
 		defined('NWLINE') OR define('NWLINE', "\n");
-		ob_start();
-		$instance->confirm(array(),'','msg');
-		$value = ob_get_contents();
-		ob_end_clean();
+		$value = $instance->confirm(array(),'','msg');
 		$this->assertTrue(is_string($value));
 		$this->assertTrue(strlen($value)>0);
 
-		ob_start();
-		$instance->confirm(array('toto'=>1,'tutu'=>2),'','msg');
-		$value = ob_get_contents();
-		ob_end_clean();
+		$value = $instance->confirm(array('toto'=>1,'tutu'=>2),'','msg');
 		$this->assertTrue(is_string($value));
 		$this->assertTrue(strlen($value)>0);
 
-		ob_start();
-		$instance->confirm(array('toto'=>1, 'tutu'=>array('t1'=>11, 't2'=>22)),'','msg');
-		$value = ob_get_contents();
-		ob_end_clean();
+		$value = $instance->confirm(array('toto'=>1, 'tutu'=>array('t1'=>11, 't2'=>22)),'','msg');
 		$this->assertTrue(is_string($value));
 		$this->assertTrue(strlen($value)>0);
 	}


### PR DESCRIPTION
Change Xoops::alert() and Xoops::confirm() to operate consistently. Both now use a to use a local XoopsTpl instance, rather than the global one, giving them proper separation. Also, both now return a rendered string, rather than displayed, so the results can easily be further processed, such as assigned for use in other templates. Two vestigial alert related methods, Xoops::error() and Xoops::result() were removed.