### PR TITLE
Making requirement bump to PHP 5.4

### DIFF
--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -70,7 +70,7 @@ function install_finalize($installer_modified)
  * @param string $value value
  * @param string $label label
  * @param string $help  help text
- * 
+ *
  * @return void
  */
 function xoFormField($name, $value, $label, $help = '')
@@ -97,7 +97,7 @@ function xoFormField($name, $value, $label, $help = '')
  * @param string $value value
  * @param string $label label
  * @param string $help  help text
- * 
+ *
  * @return void
  */
 function xoPassField($name, $value, $label, $help = '')
@@ -125,7 +125,7 @@ function xoPassField($name, $value, $label, $help = '')
  * @param string $value value
  * @param string $label label
  * @param string $help  help text
- * 
+ *
  * @return void
  */
 function xoBoolField($name, $value, $label, $help = '')
@@ -225,14 +225,10 @@ function xoDiagIfWritable($path)
  */
 function xoPhpVersion()
 {
-    if (version_compare(phpversion(), '5.3.7', '>=')) {
+    if (version_compare(phpversion(), '5.4.0', '>=')) {
         return xoDiag(1, phpversion());
     } else {
-        if (version_compare(phpversion(), '5.2.0', '>=')) {
-            return xoDiag(0, phpversion());
-        } else {
-            return xoDiag(-1, phpversion());
-        }
+        return xoDiag(-1, phpversion());
     }
 }
 
@@ -470,7 +466,7 @@ function xoFormFieldCharset($name, $value, $label, $help, $link)
 /**
  * getDbConnectionParams - build array of connection parameters from collected
  * DB_* session variables
- * 
+ *
  * @return array of Doctrine Connection parameters
  */
 function getDbConnectionParams()
@@ -486,7 +482,7 @@ function getDbConnectionParams()
         'driver' => $settings['DB_DRIVER'],
         'charset' => 'utf8',
     );
-    
+
     foreach ($driver_params as $param) {
         if (!empty($settings[$wizard->configs['db_param_names'][$param]])) {
             $connectionParams[$param] = $settings[$wizard->configs['db_param_names'][$param]];

--- a/htdocs/install/locale/en_US/welcome.php
+++ b/htdocs/install/locale/en_US/welcome.php
@@ -18,8 +18,8 @@ $content = '
 </p>
 <h3>Requirements</h3>
 <ul>
-    <li>WWW Server (<a href="http://www.apache.org/" rel="external">Apache</a>, IIS, Roxen, etc)</li>
-    <li><a href="http://www.php.net/" rel="external">PHP</a> 5.3 or higher </li>
+    <li>Web Server (<a href="http://www.apache.org/" rel="external">Apache</a>, IIS, etc)</li>
+    <li><a href="http://www.php.net/" rel="external">PHP</a> 5.4 or higher </li>
     <li><a href="http://www.mysql.com/" rel="external">MySQL</a> 5.1 or higher </li>
 </ul>
 <h3>Before you install</h3>


### PR DESCRIPTION
Time has come. Maintaining support for the past end of life 5.3 is becoming increasingly time consuming. As of now, PHP 5.4.0 will be considered the minimum requirement for XOOPS.