### PR TITLE
Stripping the domain name prefix from the username.

### DIFF
--- a/htdocs/xoops_lib/Xoops/Auth/Ads.php
+++ b/htdocs/xoops_lib/Xoops/Auth/Ads.php
@@ -65,6 +65,9 @@ class Ads extends Ldap
                     $this->setErrors(0, \XoopsLocale::E_TLS_CONNECTION_NOT_OPENED);
                 }
             }
+            // remove the domain name prefix from the username
+            $uname = explode("\\", $uname);
+            $uname = (sizeof($uname) > 0) ? $uname[sizeof($uname) - 1] : $uname = $uname[0];
             // If the uid is not in the DN we proceed to a search
             // The uid is not always in the dn
             $userUPN = $this->getUPN($uname);


### PR DESCRIPTION
When using AD integration, some users tend to sign in using:

MYDOMAIN\username instead of just typing in username, leading to an invalid username error.

This change removes "MYDOMAIN\" from the username submitted, before doing the MS AD lookup.
