### PR TITLE
Implement support for travis-ci

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,3 +7,4 @@ filter:
 tools:
     external_code_coverage:
         timeout: 900    # Timeout in seconds.
+        runs: 4         # Scrutinizer will wait for n code coverage submissions

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,4 +3,7 @@ imports:
     - php
 filter:
     excluded_paths:
-        - tests/*
+        - 'tests/*'
+tools:
+    external_code_coverage:
+        timeout: 900    # Timeout in seconds.

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,4 +7,4 @@ filter:
 tools:
     external_code_coverage:
         timeout: 900    # Timeout in seconds.
-        runs: 4         # Scrutinizer will wait for n code coverage submissions
+        runs: 3         # Scrutinizer will wait for n code coverage submissions

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
 
 before_install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,34 @@
 language: php
-script:
-  - phpunit
+
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+
+before_install:
+  - composer self-update
+
+install:
+  - composer --working-dir=htdocs/xoops_lib/ install
+  - wget https://phar.phpunit.de/phpunit-4.6.4.phar
+
+before_script:
+  - mysql -e 'create database xoops_test;'
+  - php console/console.php ci-bootstrap
+  - php console/console.php ci-install
+  - php console/console.php install-module xmf
+  - php console/console.php install-module avatars
+  - php console/console.php install-module userrank
+  - php console/console.php install-module page
+
+script:
+  - php phpunit-4.6.4.phar --configuration tests/unit/testXoopsLib.xml --coverage-clover=coverage.clover
+
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+
+matrix:
+  allow_failures:
+    - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,3 @@ script:
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-
-matrix:
-  allow_failures:
-    - php: 7.0

--- a/console/Commands/CiBootstrapCommand.php
+++ b/console/Commands/CiBootstrapCommand.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace XoopsConsole\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Xoops\Core\Yaml;
+
+class CiBootstrapCommand extends Command
+{
+    /**
+     * establish the command configuration
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setName("ci-bootstrap")
+            ->setDescription("Create a mainfile for CI processes")
+            ->setDefinition(array())
+            ->setHelp(<<<EOT
+The <info>ci-bootstrap</info> command writes a basic mainfile for use in automation
+of the travis-ci continuious integration environment.
+EOT
+             );
+    }
+
+    /**
+     * Write mainfile.php using specified configFile
+     *
+     * @param string $configFile fully qualified path to YAML configuration file
+     * @param string $mainfile   fully qualified name of mainfile to write
+     * @return integer|false
+     */
+    protected function createMainfile($configFile, $mainfile)
+    {
+        $lines = <<<'EOT'
+<?php
+if (!class_exists('XoopsBaseConfig', false)) {
+    include __DIR__ . '/class/XoopsBaseConfig.php';
+    XoopsBaseConfig::getInstance('<{$xoopsbaseconfigs}>');
+    XoopsBaseConfig::establishBCDefines();
+    define("XOOPS_MAINFILE_INCLUDED", 1);
+
+    define("XOOPS_GROUP_ADMIN", "1");
+    define("XOOPS_GROUP_USERS", "2");
+    define("XOOPS_GROUP_ANONYMOUS", "3");
+
+    $rootPath = XoopsBaseConfig::get('root-path');
+    if (!isset($xoopsOption['nocommon']) && !empty($rootPath)) {
+        include $rootPath.'/include/common.php';
+    }
+}
+EOT;
+        $lines = str_replace('<{$xoopsbaseconfigs}>', $configFile, $lines);
+
+        return file_put_contents($mainfile, $lines);
+    }
+
+    /**
+     * This builds a config file suitable for travis-ci.org
+     *
+     * @param string $configFile fully qualified path to YAML configuration file
+     * @param string $baseDir    base directory
+     * @return integer|false
+     */
+    protected function createConfigFile($configFile, $baseDir)
+    {
+        $configs = array(
+            'root-path' => $baseDir,
+            'lib-path' => $baseDir . '/xoops_lib',
+            'var-path' => $baseDir . '/xoops_data',
+            'trust-path' => $baseDir . '/xoops_lib',
+            'url' => 'http://localhost/',
+            'prot' => 'http://',
+            'asset-path' => $baseDir . '/assets',
+            'asset-url' => 'http://localhost/assets',
+            'cookie-domain' => '',
+            'cookie-path' => '/',
+            'db-type' => 'pdo_mysql',
+            'db-charset' => 'utf8',
+            'db-prefix' => 'x300',
+            'db-host' => 'localhost',
+            'db-user' => 'travis',
+            'db-pass' => '',
+            'db-name' => 'xoops_test',
+            'db-pconnect' => 0,
+            'db-parameters' => array(
+                'driver'   => 'pdo_mysql',
+                'charset'  => 'utf8',
+                'dbname'   => 'xoops_test',
+                'host'     => 'localhost',
+                'user'     => 'travis',
+                'password' => '',
+            ),
+        );
+        Yaml::saveWrapped($configs, $configFile);
+    }
+
+    /**
+     * write a configuration file in the current directory, and write htdocs/mainfile.php
+     * that references that configuration relative to the console/Commands directory.
+     *
+     * @param InputInterface  $input  input handler
+     * @param OutputInterface $output output handler
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $XContainer = $this->getApplication()->XContainer;
+
+        $configFile = $XContainer->get('configfile');
+        $mainfile = $XContainer->get('mainfile');
+        $baseDir = dirname($mainfile);
+        if (!file_exists($configFile)) {
+            $baseDir = dirname($mainfile);
+            if (false === $this->createConfigFile($configFile, $baseDir)) {
+                $output->writeln(sprintf('<error>Could not write file %s!</error>', $configFile));
+                return;
+            }
+            $output->writeln(sprintf('<info>Created config file %s.</info>', $configFile));
+        } else {
+            $output->writeln(sprintf('<info>Using existing config file %s.</info>', $configFile));
+        }
+
+        if (!file_exists($mainfile)) {
+            if (false === $this->createMainfile($configFile, $mainfile)) {
+                $output->writeln(sprintf('<error>Could not write %s!</error>', $mainfile));
+                return;
+            }
+            $output->writeln(sprintf('<info>Wrote mainfile %s</info>', $mainfile));
+        } else {
+            $output->writeln(sprintf('<info>Using existing mainfile %s</info>', $mainfile));
+        }
+
+        if (!class_exists('\XoopsBaseConfig', false)) {
+            include $baseDir . '/class/XoopsBaseConfig.php';
+            \XoopsBaseConfig::getInstance($configFile);
+        }
+        \Xoops\Core\Cache\CacheManager::createDefaultConfig();
+    }
+}

--- a/console/Commands/CiInstallCommand.php
+++ b/console/Commands/CiInstallCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace XoopsConsole\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Xoops\Core\Yaml;
+
+class CiInstallCommand extends Command
+{
+    /**
+     * establish the command configuration
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setName("ci-install")
+            ->setDescription("Install a minimal XOOPS for CI processes")
+            ->setDefinition(array())
+            ->setHelp(<<<EOT
+The <info>ci-install</info> command installs a default XOOPS system for use in the
+travis-ci continuious integration environment. This command expects on an
+appropriate mainfile.php to have been previously created, possibly using the
+<info>ci-bootstrap</info> command (only available if mainfile.php does not exist.)
+EOT
+             );
+    }
+
+    /**
+     * execute the command
+     *
+     * @param InputInterface  $input  input handler
+     * @param OutputInterface $output output handler
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // install the 'system' module
+        $xoops = \Xoops::getInstance();
+        $module = 'system';
+        $output->writeln(sprintf('Installing %s', $module));
+        if (false !== $xoops->getModuleByDirname($module)) {
+            $output->writeln(sprintf('<error>%s module is alreay installed!</error>', $module));
+            return;
+        }
+        $xoops->setTpl(new \XoopsTpl());
+        \XoopsLoad::load('module', 'system');
+        $sysmod = new \SystemModule();
+        $result = $sysmod->install($module);
+        foreach ($sysmod->trace as $message) {
+            if (is_array($message)) {
+                foreach ($message as $subMessage) {
+                    if (!is_array($subMessage)) {
+                        $output->writeln(strip_tags($subMessage));
+                    }
+                }
+            } else {
+                $output->writeln(strip_tags($message));
+            }
+        }
+        if ($result===false) {
+            $output->writeln(sprintf('<error>Install of %s module failed!</error>', $module));
+        } else {
+            $output->writeln(sprintf('<info>Install of %s module completed.</info>', $module));
+        }
+        $xoops->cache()->delete('system');
+
+        // add an admin user
+        $adminname = 'admin';
+        $adminpass = password_hash($adminname, PASSWORD_DEFAULT); // user: admin pass: admin
+        $regdate = time();
+        $result = $xoops->db()->insertPrefix(
+            'users',
+            array(
+            //  'uid'             => 1,             // mediumint(8) unsigned NOT NULL auto_increment,
+                'uname'           => $adminname,    // varchar(25) NOT NULL default '',
+                'email'           => 'nobody@localhost',    // varchar(60) NOT NULL default '',
+                'user_regdate'    => $regdate,      // int(10) unsigned NOT NULL default '0',
+                'user_viewemail'  => 1,             // tinyint(1) unsigned NOT NULL default '0',
+                'pass'            => $adminpass,    // varchar(255) NOT NULL default '',
+                'rank'            => 7,             // smallint(5) unsigned NOT NULL default '0',
+                'level'           => 5,             // tinyint(3) unsigned NOT NULL default '1',
+                'last_login'      => $regdate,      // int(10) unsigned NOT NULL default '0',
+            )
+        );
+        $output->writeln(sprintf('<info>Inserted %d user.</info>', $result));
+    }
+}

--- a/console/Commands/InstallModuleCommand.php
+++ b/console/Commands/InstallModuleCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace XoopsConsole\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class InstallModuleCommand extends Command
+{
+    /**
+     * establish the command configuration
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setName("install-module")
+            ->setDescription("Install a module")
+            ->setDefinition(array(
+                new InputArgument('module', InputArgument::REQUIRED),
+            ))->setHelp(<<<EOT
+The <info>install-module</info> command installs a module.
+EOT
+             );
+    }
+
+    /**
+     * execute the command
+     *
+     * @param InputInterface  $input  input handler
+     * @param OutputInterface $output output handler
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $module = $input->getArgument('module');
+        $output->writeln(sprintf('Installing %s', $module));
+        $xoops = \Xoops::getInstance();
+        if (false !== $xoops->getModuleByDirname($module)) {
+            $output->writeln(sprintf('<error>%s module is alreay installed!</error>', $module));
+            return;
+        }
+        $xoops->setTpl(new \XoopsTpl());
+        \XoopsLoad::load('module', 'system');
+        $sysmod = new \SystemModule();
+        $result = $sysmod->install($module);
+        foreach ($sysmod->trace as $message) {
+            if (is_array($message)) {
+                foreach ($message as $subMessage) {
+                    if (!is_array($subMessage)) {
+                        $output->writeln(strip_tags($subMessage));
+                    }
+                }
+            } else {
+                $output->writeln(strip_tags($message));
+            }
+        }
+        if ($result===false) {
+            $output->writeln(sprintf('<error>Install of %s failed!</error>', $module));
+        } else {
+            $output->writeln(sprintf('<info>Install of %s completed.</info>', $module));
+        }
+        $xoops->cache()->delete('system');
+    }
+}

--- a/console/Commands/TestCommand.php
+++ b/console/Commands/TestCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace XoopsConsole\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class TestCommand extends Command {
+    protected function configure() {
+        $this->setName("test")
+             ->setDescription("Sample description for our command named test")
+             ->setDefinition(array(
+                new InputOption('flag', 'f', InputOption::VALUE_NONE, 'Raise a flag'),
+                new InputArgument('name', InputArgument::OPTIONAL, 'A name', 'uhhh, ... Clem'),
+            ))
+             ->setHelp(<<<EOT
+The <info>test</info> command just says hello.
+EOT
+             );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) {
+        if ($input->getOption('flag')) {
+            $output->writeln('<info>flagged</info>');
+        }
+        $output->writeln(sprintf('Hello, %s!', $input->getArgument('name')));
+    }
+}

--- a/console/Commands/UninstallModuleCommand.php
+++ b/console/Commands/UninstallModuleCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace XoopsConsole\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class UninstallModuleCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setName("uninstall-module")
+            ->setDescription("Uninstall a module")
+            ->setDefinition(array(
+                new InputArgument('module', InputArgument::REQUIRED),
+            ))->setHelp(<<<EOT
+The <info>uninstall-module</info> command uninstalls a currenly installed module.
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $module = $input->getArgument('module');
+        $output->writeln(sprintf('Uninstalling %s', $module));
+        $xoops = \Xoops::getInstance();
+        if (false === $xoops->getModuleByDirname($module)) {
+            $output->writeln(sprintf('<error>%s is not an installed module!</error>', $module));
+            return;
+        }
+        $xoops->setTpl(new \XoopsTpl());
+        \XoopsLoad::load('module', 'system');
+        $sysmod = new \SystemModule();
+        $result = $sysmod->uninstall($module);
+        foreach ($sysmod->trace as $message) {
+            if (is_array($message)) {
+                foreach ($message as $subMessage) {
+                    if (!is_array($subMessage)) {
+                        $output->writeln(strip_tags($subMessage));
+                    }
+                }
+            } else {
+                $output->writeln(strip_tags($message));
+            }
+        }
+        if ($result===false) {
+            $output->writeln(sprintf('<error>Uninstall of %s failed!</error>', $module));
+        } else {
+            $output->writeln(sprintf('<info>Uninstall of %s completed.</info>', $module));
+        }
+        $xoops->cache()->delete('system');
+    }
+}

--- a/console/Commands/UpdateModuleCommand.php
+++ b/console/Commands/UpdateModuleCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace XoopsConsole\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class UpdateModuleCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setName("update-module")
+            ->setDescription("Update a module")
+            ->setDefinition(array(
+                new InputArgument('module', InputArgument::REQUIRED),
+            ))->setHelp(<<<EOT
+The <info>update-module</info> command updates a currenly installed module.
+
+This can be especially useful if the module configuration has changed, and
+it is interfering with normal online operation.
+EOT
+             );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $module = $input->getArgument('module');
+        $output->writeln(sprintf('Updating %s', $module));
+        $xoops = \Xoops::getInstance();
+        if (false === $xoops->getModuleByDirname($module)) {
+            $output->writeln(sprintf('<error>%s is not an installed module!</error>', $module));
+            return;
+        }
+        $xoops->setTpl(new \XoopsTpl());
+        \XoopsLoad::load('module', 'system');
+        $sysmod = new \SystemModule();
+        $result = $sysmod->update($module);
+        foreach ($sysmod->trace as $message) {
+            if (is_array($message)) {
+                foreach ($message as $subMessage) {
+                    if (!is_array($subMessage)) {
+                        $output->writeln(strip_tags($subMessage));
+                    }
+                }
+            } else {
+                $output->writeln(strip_tags($message));
+            }
+        }
+        if ($result===false) {
+            $output->writeln(sprintf('<error>Update of %s failed!</error>', $module));
+        } else {
+            $output->writeln(sprintf('<info>Update of %s completed.</info>', $module));
+        }
+        $xoops->cache()->delete('system');
+    }
+}

--- a/console/Library/SimpleContainer.php
+++ b/console/Library/SimpleContainer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace XoopsConsole\Library;
+
+/**
+ * A really simple container
+ *
+ * @category  XoopsConsole\Library
+ * @package   SimpleContainer
+ * @author    Richard Griffith <richard@geekwright.com>
+ * @copyright 2015 The XOOPS Project http://sourceforge.net/projects/xoops/
+ * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      http://xoops.org
+ */
+class SimpleContainer extends \ArrayObject
+{
+    /**
+     * Retrieve an attribute value.
+     *
+     * @param string $name Name of an attribute
+     *
+     * @return  mixed  The value of the attribute, or null if not set
+     */
+    public function get($name)
+    {
+        return $this->offsetGet($name);
+    }
+
+    /**
+     * Determine if an attribute exists.
+     *
+     * @param string $name An attribute name.
+     *
+     * @return boolean TRUE if the given attribute exists, otherwise FALSE.
+     */
+    public function has($name)
+    {
+        return $this->offsetExists($name);
+    }
+}

--- a/console/Library/XCApplication.php
+++ b/console/Library/XCApplication.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace XoopsConsole\Library;
+
+/**
+ * A really simple container
+ *
+ * @category  XoopsConsole\Library
+ * @package   SimpleContainer
+ * @author    Richard Griffith <richard@geekwright.com>
+ * @copyright 2015 The XOOPS Project http://sourceforge.net/projects/xoops/
+ * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      http://xoops.org
+ */
+class XCApplication extends \Symfony\Component\Console\Application
+{
+    /**
+     * @var SimpleContainer
+     */
+    public $XContainer = null;
+}

--- a/console/config.php
+++ b/console/config.php
@@ -1,0 +1,7 @@
+<?php
+$configs = array(
+    'autoloader' => dirname(__DIR__) . '/htdocs/xoops_lib/vendor/autoload.php',
+    'configfile' => getcwd() . '/xoopsCIconfigs.php',
+    'mainfile' => dirname(__DIR__) . '/htdocs/mainfile.php',
+);
+return new \XoopsConsole\Library\SimpleContainer($configs);

--- a/console/console.php
+++ b/console/console.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace XoopsConsole;
+
+use XoopsConsole\Library\XCApplication;
+
+if (php_sapi_name() != 'cli') {
+    die ('CLI use only');
+}
+
+spl_autoload_register(function ($class) {
+    $prefix = 'XoopsConsole\\';
+    $base_dir = __DIR__ . '/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+    $relative_class = substr($class, $len);
+    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+date_default_timezone_set('UTC');
+//set_time_limit(0);
+
+$configs = (include 'config.php');
+
+$mainfile = $configs->get('mainfile');
+if (file_exists($mainfile)) {
+    $xoopsOption["nocommon"] = true;
+    include_once $mainfile;
+    \Xoops::getInstance()->loadLocale();
+}
+
+if (!defined("XOOPS_MAINFILE_INCLUDED")) {
+    // apparently there is no mainfile, so fall back on the autoloader
+    require_once $configs->get('autoloader');
+}
+
+// simple psr-4 loader, example from
+// https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader-examples.md
+
+
+$app = new XCApplication('XOOPS Console', '0.1.0');
+$app->XContainer = $configs;
+
+$app->addCommands(array(
+    new \XoopsConsole\Commands\CiBootstrapCommand(),
+    new \XoopsConsole\Commands\CiInstallCommand(),
+    new \XoopsConsole\Commands\InstallModuleCommand(),
+    new \XoopsConsole\Commands\UninstallModuleCommand(),
+    new \XoopsConsole\Commands\UpdateModuleCommand(),
+));
+
+$app->run();


### PR DESCRIPTION
Includes a console command to allow minimal Xoops install from command line, and .scurinizer.yml and .travis.yml updates to run ci chain on git push.

As is, the console lives in the console directory, and can run from a fresh clone without additional configuration once a 'composer install' is run. It is kind of held together with duct tape, but it runs. Hopefuly, it demonstrates the value of the techinique and will serve as a base for future development.