### PR TITLE
Refine console, simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
 
 install:
   - composer --working-dir=htdocs/xoops_lib/ install
-  - wget https://phar.phpunit.de/phpunit-4.6.4.phar
 
 before_script:
   - mysql -e 'create database xoops_test;'
@@ -22,7 +21,7 @@ before_script:
   - php console/console.php install-module page
 
 script:
-  - php phpunit-4.6.4.phar --configuration tests/unit/testXoopsLib.xml --coverage-clover=coverage.clover
+  - htdocs/xoops_lib/vendor/bin/phpunit --configuration tests/unit/testXoopsLib.xml --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/console/Commands/InstallModuleCommand.php
+++ b/console/Commands/InstallModuleCommand.php
@@ -19,7 +19,7 @@ class InstallModuleCommand extends Command
         $this->setName("install-module")
             ->setDescription("Install a module")
             ->setDefinition(array(
-                new InputArgument('module', InputArgument::REQUIRED),
+                new InputArgument('module', InputArgument::REQUIRED, 'Module directory name'),
             ))->setHelp(<<<EOT
 The <info>install-module</info> command installs a module.
 EOT
@@ -35,9 +35,13 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $module = $input->getArgument('module');
-        $output->writeln(sprintf('Installing %s', $module));
         $xoops = \Xoops::getInstance();
+        $module = $input->getArgument('module');
+        if (false === \XoopsLoad::fileExists($xoops->path("modules/$module/xoops_version.php"))) {
+            $output->writeln(sprintf('<error>No module named %s found!</error>', $module));
+            return;
+        }
+        $output->writeln(sprintf('Installing %s', $module));
         if (false !== $xoops->getModuleByDirname($module)) {
             $output->writeln(sprintf('<error>%s module is alreay installed!</error>', $module));
             return;

--- a/console/Commands/SetConfigCommand.php
+++ b/console/Commands/SetConfigCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace XoopsConsole\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Xoops\Core\Kernel\Criteria;
+use Xoops\Core\Kernel\CriteriaCompo;
+
+class SetConfigCommand extends Command
+{
+    /**
+     * establish the command configuration
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setName("set-config")
+            ->setDescription("Set a system configuration value")
+            ->setDefinition(array(
+                new InputArgument('name', InputArgument::REQUIRED, 'Configuration item name'),
+                new InputArgument('value', InputArgument::REQUIRED, 'Value for configuration item'),
+            ))->setHelp(<<<EOT
+The <info>set-config</info> command sets a configuration item to the specified value.
+EOT
+             );
+    }
+
+    /**
+     * execute the command
+     *
+     * @param InputInterface  $input  input handler
+     * @param OutputInterface $output output handler
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $xoops = \Xoops::getInstance();
+
+        $name = $input->getArgument('name');
+        $value = $input->getArgument('value');
+
+        $configHandler = $xoops->getHandlerConfig();
+        $sysmodule = $xoops->getModuleByDirname('system');
+        if (empty($sysmodule)) {
+            $output->writeln('<error>Module system is not installed!</error>');
+            return;
+        }
+        $mid = $sysmodule->mid();
+        $criteria = new CriteriaCompo;
+        $criteria->add(new Criteria('conf_modid', $mid));
+        $criteria->add(new Criteria('conf_name', $name));
+        $objArray = $configHandler->getConfigs($criteria);
+        $configItem = reset($objArray);
+        if (empty($configItem)) {
+            $output->writeln(sprintf('<error>Config item %s not found!</error>', $name));
+            return;
+        }
+        $configItem->setConfValueForInput($value);
+        $result = $configHandler->insertConfig($configItem);
+        if ($result === false) {
+            $output->writeln(sprintf('<error>Could not set %s!</error>', $name));
+        }
+        $output->writeln(sprintf('Set %s', $name));
+    }
+}

--- a/console/Commands/UninstallModuleCommand.php
+++ b/console/Commands/UninstallModuleCommand.php
@@ -15,7 +15,7 @@ class UninstallModuleCommand extends Command
         $this->setName("uninstall-module")
             ->setDescription("Uninstall a module")
             ->setDefinition(array(
-                new InputArgument('module', InputArgument::REQUIRED),
+                new InputArgument('module', InputArgument::REQUIRED, 'Module directory name'),
             ))->setHelp(<<<EOT
 The <info>uninstall-module</info> command uninstalls a currenly installed module.
 EOT

--- a/console/Commands/UpdateModuleCommand.php
+++ b/console/Commands/UpdateModuleCommand.php
@@ -15,7 +15,7 @@ class UpdateModuleCommand extends Command
         $this->setName("update-module")
             ->setDescription("Update a module")
             ->setDefinition(array(
-                new InputArgument('module', InputArgument::REQUIRED),
+                new InputArgument('module', InputArgument::REQUIRED, 'Module directory name'),
             ))->setHelp(<<<EOT
 The <info>update-module</info> command updates a currenly installed module.
 

--- a/console/console.php
+++ b/console/console.php
@@ -52,6 +52,7 @@ $app->addCommands(array(
     new \XoopsConsole\Commands\InstallModuleCommand(),
     new \XoopsConsole\Commands\UninstallModuleCommand(),
     new \XoopsConsole\Commands\UpdateModuleCommand(),
+    new \XoopsConsole\Commands\SetConfigCommand(),
 ));
 
 $app->run();


### PR DESCRIPTION
Had a number of issues setting up the travis-ci.org, some of which were errors coming out of phpunit. To solve that, wget was used to download a known phar version to use. But, we already pull in phpunit in composer require-dev, and that establishes a phpunit command in vendor/bin, so we now use that instead.

The console worked fine as long as you didn't make a mistake, but it would happily try and install a non-existing module. That left a very nasty module entry with a blank dirname, which of course, couldn't be uninstalled. That is fixed. Also, added the ability to set a system configuration value.