### PR TITLE
Implement Xoops\Core\FixedGroups

### DIFF
--- a/htdocs/Frameworks/art/functions.cache.php
+++ b/htdocs/Frameworks/art/functions.cache.php
@@ -1,4 +1,7 @@
 <?php
+
+use Xoops\Core\FixedGroups;
+
 /**
  * Cache handlers
  *
@@ -30,7 +33,7 @@ if (!defined("FRAMEWORKS_ART_FUNCTIONS_CACHE")):
             sort($groups);
             $contentCacheId = substr(md5(implode(",", $groups) . XOOPS_DB_PASS . XOOPS_DB_NAME), 0, strlen(XOOPS_DB_USER) * 2);
         } else {
-            $contentCacheId = XOOPS_GROUP_ANONYMOUS;
+            $contentCacheId = FixedGroups::ANONYMOUS;
         }
 
         return $contentCacheId;

--- a/htdocs/class/theme.php
+++ b/htdocs/class/theme.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * XoopsTheme component class file
  *
@@ -20,8 +22,6 @@
  * @package   class
  * @version   $Id$
  */
-
-defined('XOOPS_ROOT_PATH') or die('Restricted access');
 
 /**
  * XoopsThemeFactory
@@ -342,7 +342,7 @@ class XoopsTheme
             ));
         } else {
             $this->template->assign(array(
-                'xoops_isuser' => false, 'xoops_isadmin' => false, 'xoops_usergroups' => array(XOOPS_GROUP_ANONYMOUS)
+                'xoops_isuser' => false, 'xoops_isadmin' => false, 'xoops_usergroups' => array(FixedGroups::ANONYMOUS)
             ));
         }
 
@@ -433,7 +433,7 @@ class XoopsTheme
                 $extra_string = $xoops->getConfig('locale');
                 // Generate group section
                 if (!$xoops->isUser()) {
-                    $extra_string .= '-' . XOOPS_GROUP_ANONYMOUS;
+                    $extra_string .= '-' . FixedGroups::ANONYMOUS;
                 } else {
                     $groups = $xoops->user->getGroups();
                     sort($groups);

--- a/htdocs/class/theme_blocks.php
+++ b/htdocs/class/theme_blocks.php
@@ -20,8 +20,6 @@
  * @version         $Id$
  */
 
-defined('XOOPS_ROOT_PATH') or die('Restricted access');
-
 /**
  * XoopsThemeBlocksPlugin main class
  *
@@ -93,7 +91,7 @@ class XoopsThemeBlocksPlugin extends XoopsThemePlugin
             $isStart = $xoops->getOption('show_cblock');
         }
 
-        $groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+        $groups = $xoops->getUserGroups();
 
         $oldzones = array(
             XOOPS_SIDEBLOCK_LEFT => 'canvas_left', XOOPS_SIDEBLOCK_RIGHT => 'canvas_right',

--- a/htdocs/class/xoopseditor/tinymce/tiny_mce/plugins/xoops_images/xoops_images.php
+++ b/htdocs/class/xoopseditor/tinymce/tiny_mce/plugins/xoops_images/xoops_images.php
@@ -15,7 +15,6 @@ use Xoops\Core\Request;
 
 $xoops_root_path = dirname(dirname(dirname(dirname(dirname(dirname(__DIR__))))));
 include_once $xoops_root_path . '/mainfile.php';
-defined('XOOPS_ROOT_PATH') or die('Restricted access');
 
 $xoops = Xoops::getInstance();
 $xoops->simpleHeader(false);
@@ -29,7 +28,7 @@ $op = Request::getCmd('op', 'list');
 $imgcat_id = Request::getInt('imgcat_id', 0);
 $start = Request::getInt('start', 0);
 
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+$groups = $xoops->getUserGroups();
 
 $xoopsTpl = new XoopsTpl();
 switch ($op) {

--- a/htdocs/class/xoopseditor/tinymce/tiny_mce/plugins/xoops_smilies/xoops_smilies.php
+++ b/htdocs/class/xoopseditor/tinymce/tiny_mce/plugins/xoops_smilies/xoops_smilies.php
@@ -15,7 +15,6 @@ use Xoops\Core\Request;
 
 $xoops_root_path = dirname(dirname(dirname(dirname(dirname(dirname(__DIR__))))));
 include_once $xoops_root_path . '/mainfile.php';
-defined('XOOPS_ROOT_PATH') or die('Restricted access');
 
 $xoops = Xoops::getInstance();
 $xoops->disableErrorReporting();
@@ -68,7 +67,7 @@ if ($op == 'more') {
 }
 
 // check user/group
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+$groups = $xoops->getUserGroups();
 $gperm_handler = $xoops->getHandlerGroupperm();
 $admin = $gperm_handler->checkRight('system_admin', $xoops->getHandlerModule()->getByDirName('smilies')->getVar('mid'), $groups);
 

--- a/htdocs/class/xoopseditor/tinymce/tiny_mce/plugins/xoops_xlanguage/xoops_xlanguage.php
+++ b/htdocs/class/xoopseditor/tinymce/tiny_mce/plugins/xoops_xlanguage/xoops_xlanguage.php
@@ -15,7 +15,6 @@ use Xoops\Core\Request;
 
 $xoops_root_path = dirname(dirname(dirname(dirname(dirname(dirname(__DIR__))))));
 include_once $xoops_root_path . '/mainfile.php';
-defined('XOOPS_ROOT_PATH') or die('Restricted access');
 
 $xoops = Xoops::getInstance();
 $xoops->disableErrorReporting();
@@ -44,7 +43,7 @@ if ($op == 'save') {
 }
 
 // check user/group
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+$groups = $xoops->getUserGroups();
 $gperm_handler = $xoops->getHandlerGroupperm();
 $admin = false;
 if ($gperm_handler) {

--- a/htdocs/class/xoopseditor/tinymce4/include/xoopsimagemanager.php
+++ b/htdocs/class/xoopseditor/tinymce4/include/xoopsimagemanager.php
@@ -1,1 +1,20 @@
-<?php/** *  TinyMCE adapter for XOOPS * * @copyright       The XOOPS Project http://sourceforge.net/projects/xoops/ * @license         GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html) * @package         class * @subpackage      editor * @since           2.3.0 * @author          Laurent JEN <dugris@frxoops.org> * @version         $Id: xoopsimagemanager.php 8066 2011-11-06 05:09:33Z beckmi $ */if (!defined("XOOPS_ROOT_PATH")) { die("XOOPS root path not defined"); }// check categories readability by group$groups = is_object( $GLOBALS["xoopsUser"] ) ? $GLOBALS["xoopsUser"]->getGroups() : array( XOOPS_GROUP_ANONYMOUS );$imgcat_handler =& xoops_gethandler('imagecategory');if ( count($imgcat_handler->getList($groups, 'imgcat_read', 1)) == 0 ) {    return false;}return true;?>
+<?php
+/**
+ *  TinyMCE adapter for XOOPS
+ *
+ * @copyright       The XOOPS Project http://sourceforge.net/projects/xoops/
+ * @license         GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @package         class
+ * @subpackage      editor
+ * @since           2.3.0
+ * @author          Laurent JEN <dugris@frxoops.org>
+ * @version         $Id: xoopsimagemanager.php 8066 2011-11-06 05:09:33Z beckmi $
+ */
+
+// check categories readability by group
+$groups = \Xoops::getInstance()->getUserGroups();
+$imgcat_handler =& xoops_gethandler('imagecategory');
+if (count($imgcat_handler->getList($groups, 'imgcat_read', 1)) == 0) {
+    return false;
+}
+return true;

--- a/htdocs/include/checklogin.php
+++ b/htdocs/include/checklogin.php
@@ -17,7 +17,7 @@
  * @todo            Will be refactored
  */
 
-defined('XOOPS_ROOT_PATH') or die('Restricted access');
+use Xoops\Core\FixedGroups;
 
 $xoops = Xoops::getInstance();
 
@@ -53,7 +53,7 @@ if (false != $user) {
     if ($xoops->getConfig('closesite') == 1) {
         $allowed = false;
         foreach ($user->getGroups() as $group) {
-            if (in_array($group, $xoops->getConfig('closesite_okgrp')) || XOOPS_GROUP_ADMIN == $group) {
+            if (in_array($group, $xoops->getConfig('closesite_okgrp')) || FixedGroups::ADMIN == $group) {
                 $allowed = true;
                 break;
             }

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -14,7 +14,7 @@
  * @package   kernel
  */
 
-defined('XOOPS_MAINFILE_INCLUDED') or die('Restricted access');
+use Xoops\Core\FixedGroups;
 
 /**
  * Include XoopsLoad - this should have been done in mainfile.php, but there is
@@ -224,7 +224,7 @@ if (XoopsLoad::fileExists('./xoops_version.php')) {
         }
         $xoops->userIsAdmin = $xoops->user->isAdmin($xoops->module->getVar('mid'));
     } else {
-        if (!$moduleperm_handler->checkRight('module_read', $xoops->module->getVar('mid'), XOOPS_GROUP_ANONYMOUS)) {
+        if (!$moduleperm_handler->checkRight('module_read', $xoops->module->getVar('mid'), FixedGroups::ANONYMOUS)) {
             $xoops->redirect(
                 XOOPS_URL . '/user.php?from=' . $xoops->module->getVar('dirname', 'n'),
                 1,

--- a/htdocs/include/site-closed.php
+++ b/htdocs/include/site-closed.php
@@ -19,12 +19,14 @@
  * @version         $Id$
  */
 
+use Xoops\Core\FixedGroups;
+
 $xoops = Xoops::getInstance();
 
 $allowed = false;
 if ($xoops->isUser()) {
     foreach ($xoops->user->getGroups() as $group) {
-        if (in_array($group, $xoops->getConfig('closesite_okgrp')) || XOOPS_GROUP_ADMIN == $group) {
+        if (in_array($group, $xoops->getConfig('closesite_okgrp')) || FixedGroups::ADMIN == $group) {
             $allowed = true;
             break;
         }

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * XOOPS global entry
  *
@@ -52,7 +54,7 @@ if ($xoops->isActiveModule($xoops->getConfig('startpage'))) {
         }
         $xoops->userIsAdmin = $xoops->user->isAdmin($xoops->module->getVar('mid'));
     } else {
-        if (!$moduleperm_handler->checkRight('module_read', $xoops->module->getVar('mid'), XOOPS_GROUP_ANONYMOUS)) {
+        if (!$moduleperm_handler->checkRight('module_read', $xoops->module->getVar('mid'), FixedGroups::ANONYMOUS)) {
             $xoops->redirect(XOOPS_URL . "/user.php", 1, XoopsLocale::E_NO_ACCESS_PERMISSION);
         }
     }

--- a/htdocs/kernel/groupperm.php
+++ b/htdocs/kernel/groupperm.php
@@ -18,6 +18,7 @@
  */
 
 use Xoops\Core\Database\Connection;
+use Xoops\Core\FixedGroups;
 use Xoops\Core\Kernel\Criteria;
 use Xoops\Core\Kernel\CriteriaCompo;
 use Xoops\Core\Kernel\XoopsObject;
@@ -181,7 +182,7 @@ class XoopsGroupPermHandler extends XoopsPersistableObjectHandler
             return false;
         } else {
             if (is_array($gperm_groupid)) {
-                if (in_array(XOOPS_GROUP_ADMIN, $gperm_groupid) && $trueifadmin) {
+                if (in_array(FixedGroups::ADMIN, $gperm_groupid) && $trueifadmin) {
                     return true;
                 }
                 $criteria_group = new CriteriaCompo();
@@ -189,7 +190,7 @@ class XoopsGroupPermHandler extends XoopsPersistableObjectHandler
                     $criteria_group->add(new Criteria('gperm_groupid', $gid), 'OR');
                 }
             } else {
-                if (XOOPS_GROUP_ADMIN == $gperm_groupid && $trueifadmin) {
+                if (FixedGroups::ADMIN == $gperm_groupid && $trueifadmin) {
                     return true;
                 }
                 $criteria_group = new CriteriaCompo(new Criteria('gperm_groupid', $gperm_groupid));

--- a/htdocs/mainfile.dist.php
+++ b/htdocs/mainfile.dist.php
@@ -70,10 +70,6 @@ if (!defined("XOOPS_MAINFILE_INCLUDED")) {
     // Secure file
     require XOOPS_VAR_PATH . '/data/secure.php';
 
-    define("XOOPS_GROUP_ADMIN", "1");
-    define("XOOPS_GROUP_USERS", "2");
-    define("XOOPS_GROUP_ANONYMOUS", "3");
-
     if (!class_exists('XoopsBaseConfig', false)) {
         include __DIR__ . '/class/XoopsBaseConfig.php';
         XoopsBaseConfig::bootstrapTransition();

--- a/htdocs/modules/comments/blocks/comments_blocks.php
+++ b/htdocs/modules/comments/blocks/comments_blocks.php
@@ -37,7 +37,7 @@ function b_comments_show($options)
 
     // Check modules permissions
     $moduleperm_handler = $xoops->getHandlerGroupperm();
-    $gperm_groupid = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+    $gperm_groupid = $xoops->getUserGroups();
     $criteria1 = new CriteriaCompo(new Criteria('gperm_name', 'module_read', '='));
     $criteria1->add(new Criteria('gperm_groupid', '(' . implode(',', $gperm_groupid) . ')', 'IN'));
     $perms = $moduleperm_handler->getObjects($criteria1, true);

--- a/htdocs/modules/debugbar/preloads/preload.php
+++ b/htdocs/modules/debugbar/preloads/preload.php
@@ -40,7 +40,7 @@ class DebugbarPreload extends PreloadItem
 
         if (is_null($configs)) {
             $xoops = Xoops::getInstance();
-            $user_groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+            $user_groups = $xoops->getUserGroups();
             $moduleperm_handler = $xoops->getHandlerGroupperm();
             $helper = $xoops->getModuleHelper('debugbar');
             $mid = $helper->getModule()->getVar('mid');

--- a/htdocs/modules/images/admin/categories.php
+++ b/htdocs/modules/images/admin/categories.php
@@ -9,6 +9,7 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
 use Xoops\Core\Request;
 
 /**
@@ -64,9 +65,9 @@ switch ($op) {
             // Save permissions
             $permissions = array('readgroup' => 'imgcat_read', 'writegroup' => 'imgcat_write');
             foreach ($permissions as $k => $permission) {
-                $groups = Request::getArray($k, array(XOOPS_GROUP_ADMIN));
-                if (!in_array(XOOPS_GROUP_ADMIN, $groups)) {
-                    array_push($groups, XOOPS_GROUP_ADMIN);
+                $groups = Request::getArray($k, array(FixedGroups::ADMIN));
+                if (!in_array(FixedGroups::ADMIN, $groups)) {
+                    array_push($groups, FixedGroups::ADMIN);
                 }
                 foreach ($groups as $group) {
                     $perm_obj = $xoops->getHandlerGroupperm()->create();

--- a/htdocs/modules/images/admin/header.php
+++ b/htdocs/modules/images/admin/header.php
@@ -9,6 +9,7 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
 use Xoops\Core\Request;
 
 /**
@@ -39,7 +40,7 @@ if (!$xoops->isUser() || !$xoops->isModule() || !$xoops->user->isAdmin($xoops->m
 }
 
 $gperm_handler = $xoops->getHandlerGroupperm();
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+$groups = $xoops->getUserGroups();
 
 // check WRITE right by category before continue
 if (isset($imgcat_id) && ($op == 'addfile' || $op == 'editcat' || $op == 'updatecat' || $op == 'delcatok' || $op == 'delcat')) {
@@ -50,7 +51,7 @@ if (isset($imgcat_id) && ($op == 'addfile' || $op == 'editcat' || $op == 'update
 }
 
 // Only website administator can delete categories or images
-if (!in_array(XOOPS_GROUP_ADMIN, $groups) && ($op == 'delfile' || $op == 'delfileok' || $op == 'delcatok' || $op == 'delcat')) {
+if (!in_array(FixedGroups::ADMIN, $groups) && ($op == 'delfile' || $op == 'delfileok' || $op == 'delcatok' || $op == 'delcat')) {
     $xoops->redirect($redirect, 1);
 }
 

--- a/htdocs/modules/images/class/form/category.php
+++ b/htdocs/modules/images/class/form/category.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * images module
  *
@@ -17,9 +19,6 @@
  * @author          Andricq Nicolas (AKA MusS)
  * @version         $Id$
  */
-
-defined('XOOPS_ROOT_PATH') or die('Restricted access');
-
 class ImagesCategoryForm extends Xoops\Form\ThemeForm
 {
     /**
@@ -33,8 +32,8 @@ class ImagesCategoryForm extends Xoops\Form\ThemeForm
 
         if ($obj->isNew()) {
             $title = _AM_IMAGES_CAT_ADD;
-            $read = XOOPS_GROUP_ADMIN;
-            $write = XOOPS_GROUP_ADMIN;
+            $read = FixedGroups::ADMIN;
+            $write = FixedGroups::ADMIN;
         } else {
             $title = _AM_IMAGES_CAT_EDIT;
             $read = $perm_handler->getGroupIds('imgcat_read', $obj->getVar('imgcat_id'), $xoops->module->getVar('mid'));

--- a/htdocs/modules/images/class/form/category_imagemanager.php
+++ b/htdocs/modules/images/class/form/category_imagemanager.php
@@ -28,7 +28,7 @@ class ImagesCategory_imagemanagerForm extends Xoops\Form\ThemeForm
     public function __construct($param)
     {
         $xoops = Xoops::getInstance();
-        $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+        $groups = $xoops->getUserGroups();
         extract($param);
         $helper = Xoops\Module\Helper::getHelper('images');
         $categories = $helper->getHandlerCategories()->getListByPermission($groups, 'imgcat_read');

--- a/htdocs/modules/images/class/form/categoryselect.php
+++ b/htdocs/modules/images/class/form/categoryselect.php
@@ -26,7 +26,7 @@ class ImagesCategoryselectForm extends Xoops\Form\ThemeForm
     public function __construct($imgcat_id)
     {
         $xoops = Xoops::getInstance();
-        $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+        $groups = $xoops->getUserGroups();
 
         $helper = Xoops\Module\Helper::getHelper('images');
         $categories = $helper->getHandlerCategories()->getListByPermission($groups, 'imgcat_read');

--- a/htdocs/modules/images/class/form/image.php
+++ b/htdocs/modules/images/class/form/image.php
@@ -17,9 +17,6 @@
  * @author          Andricq Nicolas (AKA MusS)
  * @version         $Id$
  */
-
-defined('XOOPS_ROOT_PATH') or die('Restricted access');
-
 class ImagesImageForm extends Xoops\Form\ThemeForm
 {
     /**
@@ -30,7 +27,7 @@ class ImagesImageForm extends Xoops\Form\ThemeForm
         $xoops = Xoops::getInstance();
         $helper = Xoops\Module\Helper::getHelper('images');
 
-        $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+        $groups = $xoops->getUserGroups();
 
         if ($obj->isNew()) {
             $title = _AM_IMAGES_IMG_ADD;

--- a/htdocs/modules/images/class/form/image_imagemanager.php
+++ b/htdocs/modules/images/class/form/image_imagemanager.php
@@ -17,7 +17,6 @@
  * @author          Andricq Nicolas (AKA MusS)
  * @version         $Id$
  */
-
 class ImagesImage_imagemanagerForm extends Xoops\Form\ThemeForm
 {
 
@@ -35,7 +34,7 @@ class ImagesImage_imagemanagerForm extends Xoops\Form\ThemeForm
         //todo, remove extract
         extract($param);
 
-        $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+        $groups = $xoops->getUserGroups();
 
         if ($obj->isNew()) {
             $title = _AM_IMAGES_IMG_ADD;

--- a/htdocs/modules/images/imagemanager.php
+++ b/htdocs/modules/images/imagemanager.php
@@ -21,7 +21,7 @@ use Xoops\Core\Request;
  * @version         $Id$
  */
 
-include dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'mainfile.php';
+include dirname(dirname(__DIR__)) . '/mainfile.php';
 
 $xoops = Xoops::getInstance();
 $helper = Images::getInstance();
@@ -37,7 +37,7 @@ if (empty($target)) {
     exit('Target not set');
 }
 
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+$groups = $xoops->getUserGroups();
 
 $xoops->simpleHeader();
 $xoopsTpl = new XoopsTpl();
@@ -117,8 +117,13 @@ switch ($op) {
 
         $xoops_upload_file = Request::getArray('xoops_upload_file', array());
 
-        $uploader = new XoopsMediaUploader(XOOPS_UPLOAD_PATH . '/images', $mimetypes,
-                    $category->getVar('imgcat_maxsize'), $category->getVar('imgcat_maxwidth'), $category->getVar('imgcat_maxheight'));
+        $uploader = new XoopsMediaUploader(
+            XOOPS_UPLOAD_PATH . '/images',
+            $mimetypes,
+            $category->getVar('imgcat_maxsize'),
+            $category->getVar('imgcat_maxwidth'),
+            $category->getVar('imgcat_maxheight')
+        );
         if ($uploader->fetchMedia($xoops_upload_file[0])) {
             $uploader->setPrefix("img");
             if (!$uploader->upload()) {
@@ -138,7 +143,7 @@ switch ($op) {
             }
         }
 
-        if ( $image_id = $helper->getHandlerImages()->insert($obj)) {
+        if ($image_id = $helper->getHandlerImages()->insert($obj)) {
             if ($category->getVar('imgcat_storetype') == 'db') {
                 $imagebody = $helper->getHandlerImagesBody()->get($image_id);
                 if (!is_object($imagebody)) {

--- a/htdocs/modules/logger/preloads/preload.php
+++ b/htdocs/modules/logger/preloads/preload.php
@@ -37,7 +37,7 @@ class LoggerPreload extends PreloadItem
 
         if (is_null($configs)) {
             $xoops = Xoops::getInstance();
-            $user_groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+            $user_groups = $xoops->getUserGroups();
             $moduleperm_handler = $xoops->getHandlerGroupperm();
             $helper = $xoops->getModuleHelper('logger');
             $mid = $helper->getModule()->getVar('mid');

--- a/htdocs/modules/menus/blocks/menus_block.php
+++ b/htdocs/modules/menus/blocks/menus_block.php
@@ -16,9 +16,6 @@
  * @since           1.0
  * @author          trabis <lusopoemas@gmail.com>
  */
-
-defined('XOOPS_ROOT_PATH') or die("XOOPS root path not defined");
-
 function menus_block_show($options)
 {
     $block = array();
@@ -207,7 +204,7 @@ function menus_mainmenu_show()
     $criteria->add(new Criteria('weight', 0, '>'));
     $modules = $module_handler->getObjectsArray($criteria, true);
     $moduleperm_handler = $xoops->getHandlerGroupperm();
-    $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+    $groups = $xoops->getUserGroups();
     $read_allowed = $moduleperm_handler->getItemIds('module_read', $groups);
     $menus = array();
     $menu = $helper->getHandlerMenu()->create();

--- a/htdocs/modules/menus/class/menu.php
+++ b/htdocs/modules/menus/class/menu.php
@@ -10,6 +10,7 @@
  */
 
 use Xoops\Core\Database\Connection;
+use Xoops\Core\FixedGroups;
 
 /**
  * @copyright       The XOOPS Project http://sourceforge.net/projects/xoops/
@@ -36,7 +37,7 @@ class MenusMenu extends XoopsObject
         $this->initVar('link', XOBJ_DTYPE_TXTBOX);
         $this->initVar('weight', XOBJ_DTYPE_INT, 255);
         $this->initVar('target', XOBJ_DTYPE_TXTBOX, '_self');
-        $this->initVar('groups', XOBJ_DTYPE_ARRAY, serialize(array(XOOPS_GROUP_ANONYMOUS, XOOPS_GROUP_USERS)));
+        $this->initVar('groups', XOBJ_DTYPE_ARRAY, serialize(array(FixedGroups::ANONYMOUS, FixedGroups::USERS)));
         $this->initVar('hooks', XOBJ_DTYPE_ARRAY, serialize(array()));
         $this->initVar('image', XOBJ_DTYPE_TXTBOX);
         $this->initVar('css', XOBJ_DTYPE_TXTBOX);

--- a/htdocs/modules/menus/decorators/default/decorator.php
+++ b/htdocs/modules/menus/decorators/default/decorator.php
@@ -17,9 +17,6 @@
  * @author          trabis <lusopoemas@gmail.com>
  * @version         $Id$
  */
-
-defined("XOOPS_ROOT_PATH") or die("XOOPS root path not defined");
-
 class MenusDefaultDecorator extends MenusDecoratorAbstract implements MenusDecoratorInterface
 {
     protected $user;
@@ -56,7 +53,7 @@ class MenusDefaultDecorator extends MenusDecoratorAbstract implements MenusDecor
         }
         $this->user = $user->getValues();
         $this->owner = $owner->getValues();
-        $this->user_groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+        $this->user_groups = $xoops->getUserGroups();
         $this->user_uid = $xoops->isUser() ? $xoops->user->getVar('uid') : 0;
         $this->get_uid = isset($_GET['uid']) ? intval($_GET['uid']) : 0;
     }

--- a/htdocs/modules/monolog/preloads/preload.php
+++ b/htdocs/modules/monolog/preloads/preload.php
@@ -44,7 +44,7 @@ class MonologPreload extends PreloadItem
         }
         /*
         if (!array_key_exists('phpfire_enable', self::$configs)) {
-            $user_groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+            $user_groups = $xoops->getUserGroups();
             $moduleperm_handler = $xoops->getHandlerGroupperm();
             $helper = $xoops->getModuleHelper('monolog');
             $mid = $helper->getModule()->getVar('mid');

--- a/htdocs/modules/page/class/page_content.php
+++ b/htdocs/modules/page/class/page_content.php
@@ -14,12 +14,11 @@ use Xoops\Core\Database\Connection;
 /**
  * page module
  *
- * @copyright       The XOOPS Project http://sourceforge.net/projects/xoops/
- * @license         GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
- * @package         page
- * @since           2.6.0
- * @author          Mage Grégory (AKA Mage)
- * @version         $Id$
+ * @copyright The XOOPS Project http://sourceforge.net/projects/xoops/
+ * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @package   page
+ * @since     2.6.0
+ * @author    Mage Grégory (AKA Mage)
  */
 
 class PagePage_content extends XoopsObject
@@ -171,7 +170,7 @@ class PagePage_contentHandler extends XoopsPersistableObjectHandler
 
 
         // get permitted id
-        $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+        $groups = $xoops->getUserGroups();
         $pages_ids = $helper->getGrouppermHandler()->getItemIds('page_view_item', $groups, $module_id);
 
         // criteria
@@ -193,7 +192,7 @@ class PagePage_contentHandler extends XoopsPersistableObjectHandler
         $module_id = $helper->getModule()->getVar('mid');
 
         // get permitted id
-        $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+        $groups = $xoops->getUserGroups();
         $pages_ids = $helper->getGrouppermHandler()->getItemIds('page_view_item', $groups, $module_id);
 
         // criteria

--- a/htdocs/modules/page/header.php
+++ b/htdocs/modules/page/header.php
@@ -39,7 +39,7 @@ $rating_Handler = $helper->getRatingHandler();
 $gperm_Handler = $helper->getGrouppermHandler();
 
 //permission
-$groups = $helper->getUserGroups();
+$groups = $xoops->getUserGroups();
 $uid = $helper->getUserId();
 
 // Define Stylesheet

--- a/htdocs/modules/profile/admin/deactivate.php
+++ b/htdocs/modules/profile/admin/deactivate.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * Extended User Profile
  *
@@ -33,7 +35,7 @@ if (!$user || $user->isNew()) {
     $xoops->redirect("index.php", 2, _PROFILE_AM_USERDONEXIT);
 }
 
-if (in_array(XOOPS_GROUP_ADMIN, $user->getGroups())) {
+if (in_array(FixedGroups::ADMIN, $user->getGroups())) {
     $xoops->redirect("index.php", 2, _PROFILE_AM_CANNOTDEACTIVATEWEBMASTERS);
 }
 $user->setVar('level', $_REQUEST['level']);

--- a/htdocs/modules/profile/admin/permissions.php
+++ b/htdocs/modules/profile/admin/permissions.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * Extended User Profile
  *
@@ -80,7 +82,7 @@ if ($op == "access") {
     $member_handler = $xoops->getHandlerMember();
     $glist = $member_handler->getGroupList();
     foreach (array_keys($glist) as $i) {
-        if ($i != XOOPS_GROUP_ANONYMOUS) {
+        if ($i != FixedGroups::ANONYMOUS) {
             $form->addItem($i, $glist[$i]);
         }
     }

--- a/htdocs/modules/profile/admin/user.php
+++ b/htdocs/modules/profile/admin/user.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * Extended User Profile
  *
@@ -52,7 +54,7 @@ switch ($op) {
         $xoops->loadLanguage("main", $xoops->module->getVar('dirname', 'n'));
         include_once dirname(__DIR__) . '/include/forms.php';
         $obj = $handler->createUser();
-        $obj->setGroups(array(XOOPS_GROUP_USERS));
+        $obj->setGroups(array(FixedGroups::USERS));
         $form = profile_getUserForm($obj);
         $form->display();
         break;
@@ -60,7 +62,7 @@ switch ($op) {
     case "edit":
         $xoops->loadLanguage("main", $xoops->module->getVar('dirname', 'n'));
         $obj = $handler->getUser($_REQUEST['id']);
-        if (in_array(XOOPS_GROUP_ADMIN, $obj->getGroups()) && !in_array(XOOPS_GROUP_ADMIN, $xoops->user->getGroups())) {
+        if (in_array(FixedGroups::ADMIN, $obj->getGroups()) && !in_array(FixedGroups::ADMIN, $xoops->user->getGroups())) {
             // If not webmaster trying to edit a webmaster - disallow
             $xoops->redirect("user.php", 3, XoopsLocale::E_NO_ACTION_PERMISSION);
         }
@@ -205,7 +207,7 @@ switch ($op) {
         }
         $obj = $handler->getUser($_REQUEST['id']);
         $groups = $obj->getGroups();
-        if (in_array(XOOPS_GROUP_ADMIN, $groups)) {
+        if (in_array(FixedGroups::ADMIN, $groups)) {
             $xoops->redirect('user.php', 3, _PROFILE_AM_CANNOTDELETEADMIN, false);
         }
 

--- a/htdocs/modules/profile/admin/visibility.php
+++ b/htdocs/modules/profile/admin/visibility.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * Extended User Profile
  *
@@ -94,7 +96,7 @@ $sel_ug = new Xoops\Form\Select(_PROFILE_AM_FIELDVISIBLEFOR, 'ug');
 $sel_ug->addOptionArray($groups);
 $add_form->addElement($sel_ug);
 
-unset($groups[XOOPS_GROUP_ANONYMOUS]);
+unset($groups[FixedGroups::ANONYMOUS]);
 $sel_pg = new Xoops\Form\Select(_PROFILE_AM_FIELDVISIBLEON, 'pg');
 $sel_pg->addOptionArray($groups);
 $add_form->addElement($sel_pg);

--- a/htdocs/modules/profile/include/install.php
+++ b/htdocs/modules/profile/include/install.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * Extended User Profile
  *
@@ -78,7 +80,7 @@ function profile_install_initializeProfiles()
 
     $xoopsDB->queryF("INSERT INTO " . $xoopsDB->prefix("profile_profile") . " (profile_id) " . " SELECT uid " . " FROM " . $xoopsDB->prefix("users"));
 
-    $sql = "INSERT INTO " . $xoopsDB->prefix("group_permission") . " (gperm_groupid, gperm_itemid, gperm_modid, gperm_name) " . " VALUES " . " (" . XOOPS_GROUP_ADMIN . ", " . XOOPS_GROUP_ADMIN . ", {$module_id}, 'profile_access'), " . " (" . XOOPS_GROUP_ADMIN . ", " . XOOPS_GROUP_USERS . ", {$module_id}, 'profile_access'), " . " (" . XOOPS_GROUP_USERS . ", " . XOOPS_GROUP_USERS . ", {$module_id}, 'profile_access'), " . " (" . XOOPS_GROUP_ANONYMOUS . ", " . XOOPS_GROUP_USERS . ", {$module_id}, 'profile_access') " . " ";
+    $sql = "INSERT INTO " . $xoopsDB->prefix("group_permission") . " (gperm_groupid, gperm_itemid, gperm_modid, gperm_name) " . " VALUES " . " (" . FixedGroups::ADMIN . ", " . FixedGroups::ADMIN . ", {$module_id}, 'profile_access'), " . " (" . FixedGroups::ADMIN . ", " . FixedGroups::USERS . ", {$module_id}, 'profile_access'), " . " (" . FixedGroups::USERS . ", " . FixedGroups::USERS . ", {$module_id}, 'profile_access'), " . " (" . FixedGroups::ANONYMOUS . ", " . FixedGroups::USERS . ", {$module_id}, 'profile_access') " . " ";
     $xoopsDB->queryF($sql);
 
 }
@@ -133,13 +135,13 @@ function profile_install_addField($name, $title, $description, $category, $type,
         " (gperm_groupid, gperm_itemid, gperm_modid, gperm_name) " .
         " VALUES " .
         ($canedit ?
-            " (" . XOOPS_GROUP_ADMIN . ", {$gperm_itemid}, {$gperm_modid}, 'profile_edit'), "
+            " (" . FixedGroups::ADMIN . ", {$gperm_itemid}, {$gperm_modid}, 'profile_edit'), "
         : "" ) .
         ($canedit == 1 ?
-            " (" . XOOPS_GROUP_USERS . ", {$gperm_itemid}, {$gperm_modid}, 'profile_edit'), "
+            " (" . FixedGroups::USERS . ", {$gperm_itemid}, {$gperm_modid}, 'profile_edit'), "
         : "" ) .
-        " (" . XOOPS_GROUP_ADMIN . ", {$gperm_itemid}, {$gperm_modid}, 'profile_search'), " .
-        " (" . XOOPS_GROUP_USERS . ", {$gperm_itemid}, {$gperm_modid}, 'profile_search') " .
+        " (" . FixedGroups::ADMIN . ", {$gperm_itemid}, {$gperm_modid}, 'profile_search'), " .
+        " (" . FixedGroups::USERS . ", {$gperm_itemid}, {$gperm_modid}, 'profile_search') " .
         " ";
     $xoopsDB->query($sql);
 
@@ -147,12 +149,12 @@ function profile_install_addField($name, $title, $description, $category, $type,
         $sql = "INSERT INTO " . $xoopsDB->prefix("profile_visibility") .
             " (field_id, user_group, profile_group) " .
             " VALUES " .
-            " ({$gperm_itemid}, " . XOOPS_GROUP_ADMIN . ", " . XOOPS_GROUP_ADMIN . "), " .
-            " ({$gperm_itemid}, " . XOOPS_GROUP_ADMIN . ", " . XOOPS_GROUP_USERS . "), " .
-            " ({$gperm_itemid}, " . XOOPS_GROUP_USERS . ", " . XOOPS_GROUP_ADMIN . "), " .
-            " ({$gperm_itemid}, " . XOOPS_GROUP_USERS . ", " . XOOPS_GROUP_USERS . "), " .
-            " ({$gperm_itemid}, " . XOOPS_GROUP_ANONYMOUS . ", " . XOOPS_GROUP_ADMIN . "), " .
-            " ({$gperm_itemid}, " . XOOPS_GROUP_ANONYMOUS . ", " . XOOPS_GROUP_USERS . ")" .
+            " ({$gperm_itemid}, " . FixedGroups::ADMIN . ", " . FixedGroups::ADMIN . "), " .
+            " ({$gperm_itemid}, " . FixedGroups::ADMIN . ", " . FixedGroups::USERS . "), " .
+            " ({$gperm_itemid}, " . FixedGroups::USERS . ", " . FixedGroups::ADMIN . "), " .
+            " ({$gperm_itemid}, " . FixedGroups::USERS . ", " . FixedGroups::USERS . "), " .
+            " ({$gperm_itemid}, " . FixedGroups::ANONYMOUS . ", " . FixedGroups::ADMIN . "), " .
+            " ({$gperm_itemid}, " . FixedGroups::ANONYMOUS . ", " . FixedGroups::USERS . ")" .
             " ";
         $xoopsDB->query($sql);
     }
@@ -170,13 +172,21 @@ function profile_install_setPermissions($field_id, $module_id, $canedit, $visibl
     $gperm_itemid = $field_id;
     $gperm_modid = $module_id;
     $sql = "INSERT INTO " . $xoopsDB->prefix("group_permission") . " (gperm_groupid, gperm_itemid, gperm_modid, gperm_name) " . " VALUES " . ($canedit
-            ? " (" . XOOPS_GROUP_ADMIN . ", {$gperm_itemid}, {$gperm_modid}, 'profile_edit'), " : "") . ($canedit == 1
-            ? " (" . XOOPS_GROUP_USERS . ", {$gperm_itemid}, {$gperm_modid}, 'profile_edit'), "
-            : "") . " (" . XOOPS_GROUP_ADMIN . ", {$gperm_itemid}, {$gperm_modid}, 'profile_search'), " . " (" . XOOPS_GROUP_USERS . ", {$gperm_itemid}, {$gperm_modid}, 'profile_search') " . " ";
+            ? " (" . FixedGroups::ADMIN . ", {$gperm_itemid}, {$gperm_modid}, 'profile_edit'), " : "") . ($canedit == 1
+            ? " (" . FixedGroups::USERS . ", {$gperm_itemid}, {$gperm_modid}, 'profile_edit'), "
+            : "") . " (" . FixedGroups::ADMIN . ", {$gperm_itemid}, {$gperm_modid}, 'profile_search'), " . " (" . FixedGroups::USERS . ", {$gperm_itemid}, {$gperm_modid}, 'profile_search') " . " ";
     $xoopsDB->queryF($sql);
 
     if ($visible) {
-        $sql = "INSERT INTO " . $xoopsDB->prefix("profile_visibility") . " (field_id, user_group, profile_group) " . " VALUES " . " ({$gperm_itemid}, " . XOOPS_GROUP_ADMIN . ", " . XOOPS_GROUP_ADMIN . "), " . " ({$gperm_itemid}, " . XOOPS_GROUP_ADMIN . ", " . XOOPS_GROUP_USERS . "), " . " ({$gperm_itemid}, " . XOOPS_GROUP_USERS . ", " . XOOPS_GROUP_ADMIN . "), " . " ({$gperm_itemid}, " . XOOPS_GROUP_USERS . ", " . XOOPS_GROUP_USERS . "), " . " ({$gperm_itemid}, " . XOOPS_GROUP_ANONYMOUS . ", " . XOOPS_GROUP_ADMIN . "), " . " ({$gperm_itemid}, " . XOOPS_GROUP_ANONYMOUS . ", " . XOOPS_GROUP_USERS . ")" . " ";
+        $sql = "INSERT INTO " . $xoopsDB->prefix("profile_visibility")
+            . " (field_id, user_group, profile_group) "
+            . " VALUES "
+            . " ({$gperm_itemid}, " . FixedGroups::ADMIN . ", " . FixedGroups::ADMIN . "), "
+            . " ({$gperm_itemid}, " . FixedGroups::ADMIN . ", " . FixedGroups::USERS . "), "
+            . " ({$gperm_itemid}, " . FixedGroups::USERS . ", " . FixedGroups::ADMIN . "), "
+            . " ({$gperm_itemid}, " . FixedGroups::USERS . ", " . FixedGroups::USERS . "), "
+            . " ({$gperm_itemid}, " . FixedGroups::ANONYMOUS . ", " . FixedGroups::ADMIN . "), "
+            . " ({$gperm_itemid}, " . FixedGroups::ANONYMOUS . ", " . FixedGroups::USERS . ")" . " ";
         $xoopsDB->queryF($sql);
     }
 }

--- a/htdocs/modules/profile/index.php
+++ b/htdocs/modules/profile/index.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * Extended User Profile
  *
@@ -21,7 +23,7 @@
  * @version         $Id$
  */
 
-include __DIR__ . DIRECTORY_SEPARATOR . 'header.php';
+include __DIR__ . '/header.php';
 $xoops = Xoops::getInstance();
 
 $op = 'main';
@@ -97,7 +99,7 @@ if ($op == 'delete') {
         $xoops->redirect(XOOPS_URL . '/', 5, XoopsLocale::E_NO_ACTION_PERMISSION);
     } else {
         $groups = $xoops->user->getGroups();
-        if (in_array(XOOPS_GROUP_ADMIN, $groups)) {
+        if (in_array(FixedGroups::ADMIN, $groups)) {
             // users in the webmasters group may not be deleted
             $xoops->redirect(XOOPS_URL . '/', 5, XoopsLocale::E_USER_IN_WEBMASTER_GROUP_CANNOT_BE_REMOVED);
         }
@@ -109,7 +111,7 @@ if ($op == 'delete') {
                 'user.php',
                 XoopsLocale::Q_ARE_YOU_SURE_TO_DELETE_ACCOUNT . '<br/>' . XoopsLocale::THIS_WILL_REMOVE_ALL_YOUR_INFO
             );
-            include __DIR__ . DIRECTORY_SEPARATOR . 'footer.php';
+            include __DIR__ . '/footer.php';
         } else {
             $del_uid = $xoops->user->getVar("uid");
             if (false != $xoops->getHandlerMember()->deleteUser($xoops->user)) {

--- a/htdocs/modules/profile/register.php
+++ b/htdocs/modules/profile/register.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * Extended User Profile
  *
@@ -22,7 +24,7 @@
  * @version         $Id$
  */
 
-include __DIR__ . DIRECTORY_SEPARATOR . 'header.php';
+include __DIR__ . '/header.php';
 $xoops = Xoops::getInstance();
 
 if ($xoops->isUser()) {
@@ -240,7 +242,7 @@ if ($current_step > 0 && empty($stop) && (!empty($steps[$current_step - 1]['step
             }
 
             $message = "";
-            if (!$member_handler->addUserToGroup(XOOPS_GROUP_USERS, $newuser->getVar('uid'))) {
+            if (!$member_handler->addUserToGroup(FixedGroups::USERS, $newuser->getVar('uid'))) {
                 $message = _PROFILE_MA_REGISTER_NOTGROUP . "<br />";
             } else {
                 if ($xoops->getConfig('activation_type') == 1) {
@@ -326,4 +328,4 @@ if (!empty($stop) || isset($steps[$current_step])) {
     $_SESSION['profile_post'] = null;
 }
 
-include __DIR__ . DIRECTORY_SEPARATOR . 'footer.php';
+include __DIR__ . '/footer.php';

--- a/htdocs/modules/profile/search.php
+++ b/htdocs/modules/profile/search.php
@@ -23,13 +23,13 @@ use Xoops\Core\Kernel\Criteria;
  * @version         $Id$
  */
 
-include __DIR__ . DIRECTORY_SEPARATOR . 'header.php';
+include __DIR__ . '/header.php';
 $xoops = Xoops::getInstance();
 $myts = MyTextSanitizer::getInstance();
 
 $limit_default = 20;
 $op = isset($_REQUEST['op']) ? $_REQUEST['op'] : "search";
-$groups = $xoops->user ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+$groups = $xoops->getUserGroups();
 $searchable_types = array(
     'textbox', 'select', 'radio', 'yesno', 'date', 'datetime', 'timezone', 'language'
 );
@@ -420,4 +420,4 @@ switch ($op) {
         }
         break;
 }
-include __DIR__ . DIRECTORY_SEPARATOR . 'footer.php';
+include __DIR__ . '/footer.php';

--- a/htdocs/modules/profile/user.php
+++ b/htdocs/modules/profile/user.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * Extended User Profile
  *
@@ -21,7 +23,7 @@
  * @version         $Id$
  */
 
-include __DIR__ . DIRECTORY_SEPARATOR . 'header.php';
+include __DIR__ . '/header.php';
 
 $xoops = Xoops::getInstance();
 $op = 'main';
@@ -51,7 +53,7 @@ if ($op == 'main') {
         $xoops->tpl()->assign('lang_youremail', XoopsLocale::C_YOUR_EMAIL);
         $xoops->tpl()->assign('lang_sendpassword', XoopsLocale::SEND_PASSWORD);
         $xoops->tpl()->assign('mailpasswd_token', $xoops->security()->createToken());
-        include __DIR__ . DIRECTORY_SEPARATOR . 'footer.php';
+        include __DIR__ . '/footer.php';
     }
     if (!empty($_GET['xoops_redirect'])) {
         $redirect = trim($_GET['xoops_redirect']);
@@ -100,15 +102,15 @@ if ($op == 'delete') {
         $xoops->redirect(XOOPS_URL . '/', 5, XoopsLocale::E_NO_ACTION_PERMISSION);
     } else {
         $groups = $xoops->user->getGroups();
-        if (in_array(XOOPS_GROUP_ADMIN, $groups)) {
+        if (in_array(FixedGroups::ADMIN, $groups)) {
             // users in the webmasters group may not be deleted
             $xoops->redirect(XOOPS_URL . '/', 5, XoopsLocale::E_USER_IN_WEBMASTER_GROUP_CANNOT_BE_REMOVED);
         }
         $ok = !isset($_POST['ok']) ? 0 : intval($_POST['ok']);
         if ($ok != 1) {
-            include __DIR__ . DIRECTORY_SEPARATOR . 'header.php';
+            include __DIR__ . '/header.php';
             echo $xoops->confirm(array('op' => 'delete', 'ok' => 1), 'user.php', XoopsLocale::Q_ARE_YOU_SURE_TO_DELETE_ACCOUNT . '<br/>' . XoopsLocale::THIS_WILL_REMOVE_ALL_YOUR_INFO);
-            include __DIR__ . DIRECTORY_SEPARATOR . 'footer.php';
+            include __DIR__ . '/footer.php';
         } else {
             $del_uid = $xoops->user->getVar("uid");
             if (false != $xoops->getHandlerMember()->deleteUser($xoops->user)) {

--- a/htdocs/modules/profile/userinfo.php
+++ b/htdocs/modules/profile/userinfo.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * Extended User Profile
  *
@@ -21,7 +23,7 @@
  * @version         $Id$
  */
 
-include __DIR__ . DIRECTORY_SEPARATOR . 'header.php';
+include __DIR__ . '/header.php';
 $xoops = Xoops::getInstance();
 include_once $xoops->path('modules/system/constants.php');
 
@@ -36,7 +38,7 @@ if ($uid <= 0) {
 }
 
 $gperm_handler = $xoops->getHandlerGroupperm();
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+$groups = $xoops->getUserGroups();
 
 if ($xoops->isUser() && $uid == $xoops->user->getVar('uid')) {
     //disable cache
@@ -71,7 +73,7 @@ if ($xoops->isUser() && $uid == $xoops->user->getVar('uid')) {
      *
      * Note:
      * "thisUser" refers to the user whose profile will be accessed; "xoopsUser" refers to the current user $xoops->user
-     * "Basic Groups" refer to XOOPS_GROUP_ADMIN, XOOPS_GROUP_USERS and XOOPS_GROUP_ANONYMOUS;
+     * "Basic Groups" refer to Xoops\Core\FixedGroups
      * "Non Basic Groups" refer to all other custom groups
      *
      * Admin groups: If thisUser belongs to admin groups, the xoopsUser has access if and only if one of xoopsUser's groups is allowed to access admin group; else
@@ -80,7 +82,7 @@ if ($xoops->isUser() && $uid == $xoops->user->getVar('uid')) {
      *
      */
     // Redirect if current user is not allowed to access the user's profile based on group permission
-    $groups_basic = array(XOOPS_GROUP_ADMIN, XOOPS_GROUP_USERS, XOOPS_GROUP_ANONYMOUS);
+    $groups_basic = array(FixedGroups::ADMIN, FixedGroups::USERS, FixedGroups::ANONYMOUS);
     $groups_thisUser = $thisUser->getGroups();
     $groups_thisUser_nonbasic = array_diff($groups_thisUser, $groups_basic);
     $groups_xoopsUser = $groups;
@@ -89,12 +91,12 @@ if ($xoops->isUser() && $uid == $xoops->user->getVar('uid')) {
 
     $rejected = false;
     if ($thisUser->isAdmin()) {
-        $rejected = !in_array(XOOPS_GROUP_ADMIN, $groups_accessible);
+        $rejected = !in_array(FixedGroups::ADMIN, $groups_accessible);
     } else {
         if ($groups_thisUser_nonbasic) {
             $rejected = !array_intersect($groups_thisUser_nonbasic, $groups_accessible);
         } else {
-            $rejected = !in_array(XOOPS_GROUP_USERS, $groups_accessible);
+            $rejected = !in_array(FixedGroups::USERS, $groups_accessible);
         }
     }
 
@@ -241,4 +243,4 @@ $xoops->tpl()->assign('email', $email);
 $xoops->tpl()->assign('avatar', $avatar);
 $xoops->tpl()->assign('recent_activity', _PROFILE_MA_RECENTACTIVITY);
 $xoops->appendConfig('profile_breadcrumbs', array('caption' => _PROFILE_MA_USERINFO));
-include __DIR__ . DIRECTORY_SEPARATOR . 'footer.php';
+include __DIR__ . '/footer.php';

--- a/htdocs/modules/publisher/admin/main.php
+++ b/htdocs/modules/publisher/admin/main.php
@@ -39,7 +39,7 @@ $ordersel = isset($_POST['ordersel']) ? $_POST['ordersel'] : $ordersel;
 
 $module_id = $publisher->getModule()->mid();
 $gperm_handler = $xoops->getHandlerGroupperm();
-$groups = $xoops->isUser() ? ($xoops->user->getGroups()) : XOOPS_GROUP_ANONYMOUS;
+$groups = $xoops->getUserGroups();
 
 // Code for the page
 
@@ -126,7 +126,7 @@ switch ($sortsel) {
         $sorttxtweight = "selected='selected'";
         break;
 
-    default :
+    default:
         $sorttxtitemid = "selected='selected'";
         break;
 }
@@ -136,41 +136,41 @@ switch ($ordersel) {
         $ordertxtasc = "selected='selected'";
         break;
 
-    default :
+    default:
         $ordertxtdesc = "selected='selected'";
         break;
 }
 
 switch ($statussel) {
-    case _PUBLISHER_STATUS_ALL :
+    case _PUBLISHER_STATUS_ALL:
         $selectedtxt0 = "selected='selected'";
         $caption = _AM_PUBLISHER_ALL;
         $cond = "";
         $status_explaination = _AM_PUBLISHER_ALL_EXP;
         break;
 
-    case _PUBLISHER_STATUS_SUBMITTED :
+    case _PUBLISHER_STATUS_SUBMITTED:
         $selectedtxt1 = "selected='selected'";
         $caption = _CO_PUBLISHER_SUBMITTED;
         $cond = " WHERE status = " . _PUBLISHER_STATUS_SUBMITTED . " ";
         $status_explaination = _AM_PUBLISHER_SUBMITTED_EXP;
         break;
 
-    case _PUBLISHER_STATUS_PUBLISHED :
+    case _PUBLISHER_STATUS_PUBLISHED:
         $selectedtxt2 = "selected='selected'";
         $caption = _CO_PUBLISHER_PUBLISHED;
         $cond = " WHERE status = " . _PUBLISHER_STATUS_PUBLISHED . " ";
         $status_explaination = _AM_PUBLISHER_PUBLISHED_EXP;
         break;
 
-    case _PUBLISHER_STATUS_OFFLINE :
+    case _PUBLISHER_STATUS_OFFLINE:
         $selectedtxt3 = "selected='selected'";
         $caption = _CO_PUBLISHER_OFFLINE;
         $cond = " WHERE status = " . _PUBLISHER_STATUS_OFFLINE . " ";
         $status_explaination = _AM_PUBLISHER_OFFLINE_EXP;
         break;
 
-    case _PUBLISHER_STATUS_REJECTED :
+    case _PUBLISHER_STATUS_REJECTED:
         $selectedtxt4 = "selected='selected'";
         $caption = _CO_PUBLISHER_REJECTED;
         $cond = " WHERE status = " . _PUBLISHER_STATUS_REJECTED . " ";
@@ -231,7 +231,7 @@ if ($numrows > 0) {
 
         switch ($itemsObj[$i]->getVar('status')) {
 
-            case _PUBLISHER_STATUS_SUBMITTED :
+            case _PUBLISHER_STATUS_SUBMITTED:
                 $statustxt = _CO_PUBLISHER_SUBMITTED;
                 $approve = "<a href='item.php?op=mod&itemid=" . $itemsObj[$i]->getVar('itemid'). "'><img src='" . XOOPS_URL . "/modules/" . $publisher->getModule()->dirname() . "/images/links/approve.gif' title='" . _AM_PUBLISHER_SUBMISSION_MODERATE . "' alt='" . _AM_PUBLISHER_SUBMISSION_MODERATE . "' /></a>&nbsp;";
                 $clone = '';
@@ -239,7 +239,7 @@ if ($numrows > 0) {
                 $modify = "";
                 break;
 
-            case _PUBLISHER_STATUS_PUBLISHED :
+            case _PUBLISHER_STATUS_PUBLISHED:
                 $statustxt = _CO_PUBLISHER_PUBLISHED;
                 $approve = "";
                 $clone = "<a href='item.php?op=clone&itemid=" . $itemsObj[$i]->getVar('itemid'). "'><img src='" . XOOPS_URL . "/modules/" . $publisher->getModule()->dirname() . "/images/links/clone.gif' title='" . _AM_PUBLISHER_CLONE_ITEM . "' alt='" . _AM_PUBLISHER_CLONE_ITEM . "' /></a>&nbsp;";
@@ -247,7 +247,7 @@ if ($numrows > 0) {
                 $delete = "<a href='item.php?op=del&itemid=" . $itemsObj[$i]->getVar('itemid'). "'><img src='" . XOOPS_URL . "/modules/" . $publisher->getModule()->dirname() . "/images/links/delete.png' title='" . _AM_PUBLISHER_DELETEITEM . "' alt='" . _AM_PUBLISHER_DELETEITEM . "' /></a>";
                 break;
 
-            case _PUBLISHER_STATUS_OFFLINE :
+            case _PUBLISHER_STATUS_OFFLINE:
                 $statustxt = _CO_PUBLISHER_OFFLINE;
                 $approve = "";
                 $clone = "<a href='item.php?op=clone&itemid=" . $itemsObj[$i]->getVar('itemid'). "'><img src='" . XOOPS_URL . "/modules/" . $publisher->getModule()->dirname() . "/images/links/clone.gif' title='" . _AM_PUBLISHER_CLONE_ITEM . "' alt='" . _AM_PUBLISHER_CLONE_ITEM . "' /></a>&nbsp;";
@@ -255,7 +255,7 @@ if ($numrows > 0) {
                 $delete = "<a href='item.php?op=del&itemid=" . $itemsObj[$i]->getVar('itemid'). "'><img src='" . XOOPS_URL . "/modules/" . $publisher->getModule()->dirname() . "/images/links/delete.png' title='" . _AM_PUBLISHER_DELETEITEM . "' alt='" . _AM_PUBLISHER_DELETEITEM . "' /></a>";
                 break;
 
-            case _PUBLISHER_STATUS_REJECTED :
+            case _PUBLISHER_STATUS_REJECTED:
                 $statustxt = _CO_PUBLISHER_REJECTED;
                 $approve = "";
                 $clone = "<a href='item.php?op=clone&itemid=" . $itemsObj[$i]->getVar('itemid'). "'><img src='" . XOOPS_URL . "/modules/" . $publisher->getModule()->dirname() . "/images/links/clone.gif' title='" . _AM_PUBLISHER_CLONE_ITEM . "' alt='" . _AM_PUBLISHER_CLONE_ITEM . "' /></a>&nbsp;";
@@ -263,8 +263,8 @@ if ($numrows > 0) {
                 $delete = "<a href='item.php?op=del&itemid=" . $itemsObj[$i]->getVar('itemid'). "'><img src='" . XOOPS_URL . "/modules/" . $publisher->getModule()->dirname() . "/images/links/delete.png' title='" . _AM_PUBLISHER_DELETEITEM . "' alt='" . _AM_PUBLISHER_DELETEITEM . "' /></a>";
                 break;
 
-            case "default" :
-            default :
+            case "default":
+            default:
                 $statustxt = _AM_PUBLISHER_STATUS0;
                 $approve = "";
                 $clone = '';

--- a/htdocs/modules/publisher/class/form/category.php
+++ b/htdocs/modules/publisher/class/form/category.php
@@ -69,7 +69,7 @@ class PublisherCategoryForm extends Xoops\Form\ThemeForm
         $this->addElement(new Xoops\Form\TextArea(_AM_PUBLISHER_COLDESCRIPT, 'description', $obj->getVar('description', 'e'), 7, 60));
 
         // EDITOR
-        $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+        $groups = $xoops->getUserGroups();
         $gperm_handler = $publisher->getGrouppermHandler();
         $module_id = $publisher->getModule()->mid();
         $allowed_editors = PublisherUtils::getEditors($gperm_handler->getItemIds('editors', $groups, $module_id));
@@ -205,7 +205,6 @@ class PublisherCategoryForm extends Xoops\Form\ThemeForm
 
         // No ID for category -- then it's new category, button says 'Create'
         if (!$obj->getVar('categoryid')) {
-
             $button_tray->addElement(new Xoops\Form\Button('', 'addcategory', _AM_PUBLISHER_CREATE, 'submit'));
 
             $butt_clear = new Xoops\Form\Button('', '', _AM_PUBLISHER_CLEAR, 'reset');
@@ -217,7 +216,6 @@ class PublisherCategoryForm extends Xoops\Form\ThemeForm
 
             $this->addElement($button_tray);
         } else {
-
             $button_tray->addElement(new Xoops\Form\Button('', 'addcategory', _AM_PUBLISHER_MODIFY, 'submit'));
 
             $butt_cancel = new Xoops\Form\Button('', '', _AM_PUBLISHER_CANCEL, 'button');

--- a/htdocs/modules/publisher/class/form/item.php
+++ b/htdocs/modules/publisher/class/form/item.php
@@ -65,11 +65,7 @@ class PublisherItemForm extends Xoops\Form\SimpleForm
         $publisher = Publisher::getInstance();
         $allowed_editors = PublisherUtils::getEditors($publisher->getPermissionHandler()->getGrantedItems('editors'));
 
-        if (!$xoops->isUser()) {
-            $group = array(XOOPS_GROUP_ANONYMOUS);
-        } else {
-            $group = $xoops->user->getGroups();
-        }
+        $group = $xoops->getUserGroups();
 
         parent::__construct('title', 'form', $xoops->getEnv('PHP_SELF'));
         $this->setExtra('enctype="multipart/form-data"');

--- a/htdocs/modules/publisher/class/item.php
+++ b/htdocs/modules/publisher/class/item.php
@@ -1428,7 +1428,7 @@ class PublisherItemHandler extends XoopsPersistableObjectHandler
         $xoops = Xoops::getInstance();
         $ret = array();
         $gperm_handler = $xoops->getHandlerGroupperm();
-        $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+        $groups = $xoops->getUserGroups();
         $searchin = empty($searchin) ? array(
             "title",
             "body",

--- a/htdocs/modules/publisher/class/permission.php
+++ b/htdocs/modules/publisher/class/permission.php
@@ -91,14 +91,13 @@ class PublisherPermissionHandler extends XoopsObjectHandler
         if (isset($items[$gperm_name])) {
             return $items[$gperm_name];
         }
-        global $xoopsUser;
         $ret = array();
         //Instead of calling groupperm handler and get objects, we will save some memory and do it our way
         $criteria = new CriteriaCompo(new Criteria('gperm_name', $gperm_name));
         $criteria->add(new Criteria('gperm_modid', $this->publisher->getModule()->getVar('mid')));
 
         //Get user's groups
-        $groups = is_object($xoopsUser) ? $xoopsUser->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+        $groups = \Xoops::getInstance()->getUserGroups();
         $criteria2 = new CriteriaCompo();
         foreach ($groups as $gid) {
             $criteria2->add(new Criteria('gperm_groupid', $gid), 'OR');

--- a/htdocs/modules/publisher/class/utils.php
+++ b/htdocs/modules/publisher/class/utils.php
@@ -19,11 +19,7 @@ use Xmf\Module\Session;
  * @author          trabis <lusopoemas@gmail.com>
  * @author          The SmartFactory <www.smartfactory.ca>
  * @author          trabis <lusopoemas@gmail.com>
- * @version         $Id$
  */
-
-defined("XOOPS_ROOT_PATH") or die("XOOPS root path not defined");
-
 class PublisherUtils
 {
     /**
@@ -910,7 +906,7 @@ class PublisherUtils
         $rating1 = @number_format($current_rating / $count, 1);
         $rating2 = @number_format($current_rating / $count, 2);
 
-        $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+        $groups = $xoops->getUserGroups();
         $gperm_handler = $publisher->getGrouppermHandler();
 
         if (!$gperm_handler->checkRight('global', _PUBLISHER_RATE, $groups, $publisher->getModule()->getVar('mid'))) {

--- a/htdocs/modules/publisher/include/ajax_rating.php
+++ b/htdocs/modules/publisher/include/ajax_rating.php
@@ -47,7 +47,7 @@ header("Pragma: nocache");
 $rating = intval($_REQUEST['rating']);
 $itemid = intval($_REQUEST['itemid']);
 
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+$groups = $xoops->getUserGroups();
 $gperm_handler = $publisher->getGrouppermHandler();
 $hModConfig = $xoops->getHandlerConfig();
 $module_id = $publisher->getModule()->getVar('mid');

--- a/htdocs/modules/publisher/include/ajax_upload.php
+++ b/htdocs/modules/publisher/include/ajax_upload.php
@@ -25,6 +25,8 @@
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA //
 //  ------------------------------------------------------------------------ //
 
+use Xoops\Core\FixedGroups;
+
 include dirname(dirname(dirname(__DIR__))) . '/mainfile.php';
 include_once __DIR__ . '/common.php';
 
@@ -39,11 +41,7 @@ if (!$xoops->isActiveModule('images')) {
 $publisher = Publisher::getInstance();
 $publisher->loadLanguage('common');
 
-if (!$xoops->isUser()) {
-    $group = array(XOOPS_GROUP_ANONYMOUS);
-} else {
-    $group = $xoops->user->getGroups();
-}
+$group = $xoops->getUserGroups();
 
 $filename = basename($_FILES['publisher_upload_file']['name']);
 $image_nicename = isset($_POST['image_nicename']) ? trim($_POST['image_nicename']) : '';
@@ -66,7 +64,7 @@ if (!is_object($imgcat)) {
             $error = _CO_PUBLISHER_IMAGE_CAT_NONE;
         }
     } else {
-        if (!$imgcatperm_handler->checkRight('imgcat_write', $imgcat_id, XOOPS_GROUP_ANONYMOUS)) {
+        if (!$imgcatperm_handler->checkRight('imgcat_write', $imgcat_id, FixedGroups::ANONYMOUS)) {
             $error = _CO_PUBLISHER_IMAGE_CAT_NOPERM;
         }
     }

--- a/htdocs/modules/publisher/rate.php
+++ b/htdocs/modules/publisher/rate.php
@@ -28,7 +28,7 @@ $xoops = Xoops::getInstance();
 $rating = Request::getInt('rating');
 $itemid = Request::getInt('itemid');
 
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+$groups = $xoops->getUserGroups();
 $gperm_handler = $publisher->getGrouppermHandler();
 $hModConfig = $xoops->getHandlerConfig();
 $module_id = $publisher->getModule()->getVar('mid');

--- a/htdocs/modules/publisher/search.php
+++ b/htdocs/modules/publisher/search.php
@@ -35,7 +35,7 @@ if (empty($xoopsConfigSearch["enable_search"])) {
     $xoops->redirect(PUBLISHER_URL . "/index.php", 2, XoopsLocale::E_NO_ACCESS_PERMISSION);
 }
 
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+$groups = $xoops->getUserGroups();
 $gperm_handler = $publisher->getGrouppermHandler();
 $module_id = $publisher->getModule()->mid();
 

--- a/htdocs/modules/publisher/submit.php
+++ b/htdocs/modules/publisher/submit.php
@@ -34,7 +34,7 @@ if (!$categoriesArray) {
     $xoops->redirect("index.php", 1, _MD_PUBLISHER_NEED_CATEGORY_ITEM);
 }
 
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+$groups = $xoops->getUserGroups();
 $gperm_handler = $xoops->getHandlerGroupperm();
 $module_id = $publisher->getModule()->getVar('mid');
 

--- a/htdocs/modules/search/class/form/search.php
+++ b/htdocs/modules/search/class/form/search.php
@@ -48,7 +48,7 @@ class SearchSearchForm extends Xoops\Form\ThemeForm
         }
         if (empty($modules)) {
             $gperm_handler = $xoops->getHandlerGroupperm();
-            $available_modules = $gperm_handler->getItemIds('module_read', $search->getUserGroups());
+            $available_modules = $gperm_handler->getItemIds('module_read', $xoops->getUserGroups());
             $available_plugins = \Xoops\Module\Plugin::getPlugins('search');
 
             //todo, would be nice to have the module ids availabe also

--- a/htdocs/modules/search/index.php
+++ b/htdocs/modules/search/index.php
@@ -62,7 +62,7 @@ if ($action == "results") {
 }
 
 $gperm_handler = $xoops->getHandlerGroupperm();
-$available_modules = $gperm_handler->getItemIds('module_read', $search->getUserGroups());
+$available_modules = $gperm_handler->getItemIds('module_read', $xoops->getUserGroups());
 $available_plugins = \Xoops\Module\Plugin::getPlugins('search');
 
 if ($action == 'search') {

--- a/htdocs/modules/system/admin.php
+++ b/htdocs/modules/system/admin.php
@@ -10,6 +10,7 @@
 */
 
 use Xoops\Core\Kernel\Criteria;
+use Xoops\Core\FixedGroups;
 
 /**
  * System admin
@@ -48,7 +49,7 @@ if ($system->checkRight()) {
 
             if ($category > 0) {
                 $group = $xoopsUser->getGroups();
-                if (in_array(XOOPS_GROUP_ADMIN, $group) || false != $sysperm_handler->checkRight('system_admin', $category, $group, $xoopsModule->getVar('mid'))) {
+                if (in_array(FixedGroups::ADMIN, $group) || false != $sysperm_handler->checkRight('system_admin', $category, $group, $xoopsModule->getVar('mid'))) {
                     if (XoopsLoad::fileExists($file = $xoops->path('modules/' . $xoopsModule->getVar('dirname', 'n') . '/admin/' . $fct . '/main.php'))) {
                         include_once $file;
                         unset($file);
@@ -110,7 +111,7 @@ if (false != $error) {
     $admin_page->renderTips();
     $groups = $xoopsUser->getGroups();
     $all_ok = false;
-    if (!in_array(XOOPS_GROUP_ADMIN, $groups)) {
+    if (!in_array(FixedGroups::ADMIN, $groups)) {
         $sysperm_handler = $xoops->getHandlerGroupperm();
         $ok_syscats = $sysperm_handler->getItemIds('system_admin', $groups);
     } else {

--- a/htdocs/modules/system/admin/blocksadmin/main.php
+++ b/htdocs/modules/system/admin/blocksadmin/main.php
@@ -11,6 +11,7 @@
 
 use Xoops\Core\Kernel\Criteria;
 use Xoops\Core\Kernel\CriteriaCompo;
+use Xoops\Core\FixedGroups;
 
 /**
  * Blocks Administration
@@ -47,7 +48,7 @@ $selmod = $selgen = $selgrp = $selvis = null;
 $sel = array(
     'selmod' => -2,
     'selgen' => -1,
-    'selgrp' => XOOPS_GROUP_USERS,
+    'selgrp' => FixedGroups::USERS,
     'selvis' => -1
 );
 foreach ($sel as $key => $value) {

--- a/htdocs/modules/system/admin/groups/main.php
+++ b/htdocs/modules/system/admin/groups/main.php
@@ -11,6 +11,7 @@
 
 use Xoops\Core\Kernel\Criteria;
 use Xoops\Core\Kernel\CriteriaCompo;
+use Xoops\Core\FixedGroups;
 
 /**
  * Groups Manager
@@ -92,7 +93,7 @@ switch ($op) {
             $edit_delete = '<a href="admin.php?fct=groups&amp;op=groups_edit&amp;groups_id=' . $groups_id . '">'
                 . '<img src="./images/icons/edit.png" border="0" alt="' . SystemLocale::EDIT_GROUP
                 . '" title="' . SystemLocale::EDIT_GROUP . '"></a>';
-            if (!in_array($group->getVar("groupid"), array(XOOPS_GROUP_ADMIN, XOOPS_GROUP_USERS, XOOPS_GROUP_ANONYMOUS))
+            if (!in_array($group->getVar("groupid"), array(FixedGroups::ADMIN, FixedGroups::USERS, FixedGroups::ANONYMOUS))
             ) {
                 $groups['delete'] = 1;
                 $edit_delete .= '<a href="admin.php?fct=groups&amp;op=groups_delete&amp;groups_id=' . $groups_id . '">'
@@ -236,7 +237,7 @@ switch ($op) {
             $group->setVar('name', $_POST["name"]);
             $group->setVar('description', $_POST["desc"]);
             // if this group is not one of the default groups
-            if (!in_array($group->getVar('groupid'), array(XOOPS_GROUP_ADMIN, XOOPS_GROUP_USERS, XOOPS_GROUP_ANONYMOUS))
+            if (!in_array($group->getVar('groupid'), array(FixedGroups::ADMIN, FixedGroups::USERS, FixedGroups::ANONYMOUS))
             ) {
                 if (count($system_catids) > 0) {
                     $group->setVar('group_type', 'Admin');
@@ -320,9 +321,9 @@ switch ($op) {
                     $xoops->redirect("admin.php?fct=groups", 3, implode(",", $xoops->security()->getErrors()));
                 }
                 if ($groups_id > 0 && !in_array($groups_id, array(
-                        XOOPS_GROUP_ADMIN,
-                        XOOPS_GROUP_USERS,
-                        XOOPS_GROUP_ANONYMOUS
+                        FixedGroups::ADMIN,
+                        FixedGroups::USERS,
+                        FixedGroups::ANONYMOUS
                     ))
                 ) {
                     $member_handler = $xoops->getHandlerMember();

--- a/htdocs/modules/system/admin/users/main.php
+++ b/htdocs/modules/system/admin/users/main.php
@@ -31,6 +31,7 @@
 use Xoops\Core\Kernel\Criteria;
 use Xoops\Core\Kernel\CriteriaCompo;
 use Xoops\Core\Request;
+use Xoops\Core\FixedGroups;
 
 $xoops = Xoops::getInstance();
 
@@ -104,7 +105,7 @@ switch ($op) {
             }
 
             $groups = $user->getGroups();
-            if (in_array(XOOPS_GROUP_ADMIN, $groups)) {
+            if (in_array(FixedGroups::ADMIN, $groups)) {
                 echo $xoops->alert('error', sprintf(SystemLocale::EF_CAN_NOT_DELETE_ADMIN_USER, $user->getVar("uname")));
             } elseif (!$member_handler->deleteUser($user)) {
                 echo $xoops->alert('error', sprintf(SystemLocale::EF_COULD_NOT_DELETE_USER, $user->getVar("uname")));
@@ -135,7 +136,7 @@ switch ($op) {
                 $del = intval($del);
                 $user = $member_handler->getUser($del);
                 $groups = $user->getGroups();
-                if (in_array(XOOPS_GROUP_ADMIN, $groups)) {
+                if (in_array(FixedGroups::ADMIN, $groups)) {
                     $error .= sprintf(SystemLocale::EF_CAN_NOT_DELETE_ADMIN_USER, $user->getVar("uname"));
                     $error .= '<br />';
                 } elseif (!$member_handler->deleteUser($user)) {
@@ -227,9 +228,9 @@ switch ($op) {
                     if ($_REQUEST['groups'] != array()) {
                         $oldgroups = $edituser->getGroups();
                         //If the edited user is the current user and the current user WAS in the webmaster's group and is NOT in the new groups array
-                        if ($edituser->getVar('uid') == $xoops->user->getVar('uid') && (in_array(XOOPS_GROUP_ADMIN, $oldgroups)) && !(in_array(XOOPS_GROUP_ADMIN, $_REQUEST['groups']))) {
+                        if ($edituser->getVar('uid') == $xoops->user->getVar('uid') && (in_array(FixedGroups::ADMIN, $oldgroups)) && !(in_array(FixedGroups::ADMIN, $_REQUEST['groups']))) {
                             //Add the webmaster's group to the groups array to prevent accidentally removing oneself from the webmaster's group
-                            array_push($_REQUEST['groups'], XOOPS_GROUP_ADMIN);
+                            array_push($_REQUEST['groups'], FixedGroups::ADMIN);
                         }
                         $member_handler = $xoops->getHandlerMember();
                         foreach ($oldgroups as $groupid) {

--- a/htdocs/modules/system/blocks/main.php
+++ b/htdocs/modules/system/blocks/main.php
@@ -34,7 +34,7 @@ function b_system_main_show()
     $criteria->add(new Criteria('weight', 0, '>'));
     $modules = $module_handler->getObjectsArray($criteria, true);
     $moduleperm_handler = $xoops->getHandlerGroupperm();
-    $groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+    $groups = $xoops->getUserGroups();
     $read_allowed = $moduleperm_handler->getItemIds('module_read', $groups);
     /* @var $module XoopsModule */
     foreach ($modules as $i => $module) {

--- a/htdocs/modules/system/class/form/block.php
+++ b/htdocs/modules/system/class/form/block.php
@@ -11,6 +11,7 @@
 
 use Xoops\Core\Kernel\Criteria;
 use Xoops\Core\Kernel\CriteriaCompo;
+use Xoops\Core\FixedGroups;
 
 /**
  * Blocks Form Class
@@ -53,7 +54,7 @@ class SystemBlockForm extends Xoops\Form\ThemeForm
         if ($this->obj->isNew()) {
             $title = SystemLocale::ADD_BLOCK;
             $modules = array(-1);
-            $groups = array(XOOPS_GROUP_USERS, XOOPS_GROUP_ANONYMOUS, XOOPS_GROUP_ADMIN);
+            $groups = array(FixedGroups::USERS, FixedGroups::ANONYMOUS, FixedGroups::ADMIN);
             $this->obj->setVar('block_type', 'C');
             $this->obj->setVar('visible', 1);
             $op = 'save';

--- a/htdocs/modules/system/class/form/user.php
+++ b/htdocs/modules/system/class/form/user.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * SystemUserForm
  *
@@ -52,7 +54,7 @@ class SystemUserForm extends Xoops\Form\ThemeForm
             $mailok_value = 0;
             $form_title = SystemLocale::ADD_USER;
             $form_isedit = false;
-            $groups = array(XOOPS_GROUP_USERS);
+            $groups = array(FixedGroups::USERS);
         } else {
             //Edit user
             $uid_value = $obj->getVar("uid", "E");

--- a/htdocs/modules/system/class/module.php
+++ b/htdocs/modules/system/class/module.php
@@ -10,6 +10,7 @@
 */
 
 use Xoops\Core\Database\Schema\ImportSchema;
+use Xoops\Core\FixedGroups;
 use Xoops\Core\Kernel\Criteria;
 use Xoops\Core\Kernel\CriteriaCompo;
 use Xoops\Core\Yaml;
@@ -358,9 +359,9 @@ class SystemModule
                 $this->installConfigs($module, 'add');
 
                 if ($module->getInfo('hasMain')) {
-                    $groups = array(XOOPS_GROUP_ADMIN, XOOPS_GROUP_USERS, XOOPS_GROUP_ANONYMOUS);
+                    $groups = array(FixedGroups::ADMIN, FixedGroups::USERS, FixedGroups::ANONYMOUS);
                 } else {
-                    $groups = array(XOOPS_GROUP_ADMIN);
+                    $groups = array(FixedGroups::ADMIN);
                 }
                 // retrieve all block ids for this module
                 $block_handler = $xoops->getHandlerBlock();

--- a/htdocs/modules/system/menu.php
+++ b/htdocs/modules/system/menu.php
@@ -9,6 +9,7 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
 /**
  * System menu
  *
@@ -19,8 +20,6 @@
  * @version     $Id$
  */
 
-defined('XOOPS_ROOT_PATH') or die('Restricted access');
-
 $xoops = Xoops::getInstance();
 $groups = array();
 if (is_object($xoops->user)) {
@@ -28,7 +27,7 @@ if (is_object($xoops->user)) {
 }
 
 $all_ok = false;
-if (!in_array(XOOPS_GROUP_ADMIN, $groups)) {
+if (!in_array(FixedGroups::ADMIN, $groups)) {
     $sysperm_handler = $xoops->getHandlerGroupperm();
     $ok_syscats = $sysperm_handler->getItemIds('system_admin', $groups);
 } else {

--- a/htdocs/modules/system/themes/default/menu.php
+++ b/htdocs/modules/system/themes/default/menu.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+use Xoops\Core\FixedGroups;
+
 /*
  * Xoops Cpanel oxygen menu
  *
@@ -28,10 +30,11 @@
 
 $xoops = Xoops::getInstance();
 $groups = array();
-if (is_object($xoops->user))
+if (is_object($xoops->user)) {
     $groups = $xoops->user->getGroups();
+}
 $all_ok = false;
-if (!in_array(XOOPS_GROUP_ADMIN, $groups)) {
+if (!in_array(FixedGroups::ADMIN, $groups)) {
     $sysperm_handler = $xoops->getHandlerGroupperm();
     $ok_syscats = $sysperm_handler->getItemIds('system_admin', $groups);
 } else {

--- a/htdocs/register.php
+++ b/htdocs/register.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * XOOPS Register
  *
@@ -19,7 +21,7 @@
  * @author          Kazumi Ono <webmaster@myweb.ne.jp>
  * @version         $Id$
  */
-include __DIR__ . DIRECTORY_SEPARATOR . 'mainfile.php';
+include __DIR__ . '/mainfile.php';
 
 $xoops = Xoops::getInstance();
 $xoops->events()->triggerEvent('core.register.start');
@@ -164,7 +166,7 @@ switch ($op) {
                 $xoops->footer();
             }
             $newid = $newuser->getVar('uid');
-            if (!$member_handler->addUserToGroup(XOOPS_GROUP_USERS, $newid)) {
+            if (!$member_handler->addUserToGroup(FixedGroups::USERS, $newid)) {
                 echo XoopsLocale::E_USER_NOT_REGISTERED;
                 $xoops->footer();
             }

--- a/htdocs/user.php
+++ b/htdocs/user.php
@@ -9,6 +9,8 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+
 /**
  * XOOPS User
  *
@@ -22,7 +24,7 @@
  * @author          Kazumi Ono <webmaster@myweb.ne.jp>
  */
 
-include __DIR__ . DIRECTORY_SEPARATOR . 'mainfile.php';
+include __DIR__ . '/mainfile.php';
 
 $xoops = Xoops::getInstance();
 $xoops->events()->triggerEvent('core.user.start');
@@ -123,7 +125,7 @@ if ($op == 'delete') {
         $xoops->redirect('index.php', 5, XoopsLocale::E_NO_ACTION_PERMISSION);
     } else {
         $groups = $xoops->user->getGroups();
-        if (in_array(XOOPS_GROUP_ADMIN, $groups)) {
+        if (in_array(FixedGroups::ADMIN, $groups)) {
             // users in the webmasters group may not be deleted
             $xoops->redirect('user.php', 5, XoopsLocale::E_USER_IN_WEBMASTER_GROUP_CANNOT_BE_REMOVED);
         }

--- a/htdocs/userinfo.php
+++ b/htdocs/userinfo.php
@@ -20,7 +20,7 @@
  * @version         $Id$
  */
 
-include __DIR__ . DIRECTORY_SEPARATOR . 'mainfile.php';
+include __DIR__ . '/mainfile.php';
 
 $xoops = Xoops::getInstance();
 $xoops->preload()->triggerEvent('core.userinfo.start');
@@ -33,7 +33,7 @@ if ($uid <= 0) {
     $xoops->redirect('index.php', 3, XoopsLocale::E_NO_USER_SELECTED);
 }
 $gperm_handler = $xoops->getHandlerGroupperm();
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+$groups = $xoops->getUserGroups();
 
 $isAdmin = $gperm_handler->checkRight('system_admin', XOOPS_SYSTEM_USER, $groups);
 if ($xoops->isUser()) {
@@ -183,7 +183,7 @@ $criteria->add(new Criteria('isactive', 1));
 $criteria->add(new Criteria('weight', 0, '>'));
 $modules = $module_handler->getObjectsArray($criteria, true);
 $moduleperm_handler = $xoops->getHandlerGroupperm();
-$groups = $xoops->isUser() ? $xoops->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
+$groups = $xoops->getUserGroups();
 $read_allowed = $moduleperm_handler->getItemIds('module_read', $groups);
 
 foreach (array_keys($modules) as $i) {

--- a/htdocs/xoops_lib/Xmf/Module/Admin.php
+++ b/htdocs/xoops_lib/Xmf/Module/Admin.php
@@ -63,7 +63,7 @@ class Admin
      *
      * @since  1.0
      */
-    public static function & getInstance ()
+    public static function getInstance()
     {
 
         static $instance;

--- a/htdocs/xoops_lib/Xmf/Module/Permission.php
+++ b/htdocs/xoops_lib/Xmf/Module/Permission.php
@@ -84,7 +84,7 @@ class Permission extends AbstractHelper
      **/
     public function checkPermission($gperm_name, $gperm_itemid)
     {
-        $gperm_groupid = $this->getUserGroups();
+        $gperm_groupid = $this->xoops->getUserGroups();
 
         return $this->perm->checkRight(
             $gperm_name,
@@ -112,7 +112,7 @@ class Permission extends AbstractHelper
         $time = 3,
         $message = ''
     ) {
-        $gperm_groupid = $this->getUserGroups();
+        $gperm_groupid = $this->xoops->getUserGroups();
         $permission = $this->perm->checkRight(
             $gperm_name,
             $gperm_itemid,
@@ -123,24 +123,6 @@ class Permission extends AbstractHelper
             $helper = Helper::getHelper($this->dirname);
             $helper->redirect($url, $time, $message);
         }
-    }
-
-    /**
-     * Get groups user belong to, even for annonymous user
-     *
-     * @return array of groups the current user is associted with
-     */
-    public function getUserGroups()
-    {
-        if ($this->xoops) {
-            $groupids = $this->xoops->isUser() ?
-                $this->xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
-        } else {
-            $groupids = is_object($GLOBALS['xoopsUser']) ?
-                $GLOBALS['xoopsUser']->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
-        }
-
-        return $groupids;
     }
 
     /**

--- a/htdocs/xoops_lib/Xoops.php
+++ b/htdocs/xoops_lib/Xoops.php
@@ -10,6 +10,7 @@
 */
 
 use Xoops\Core\Request;
+use Xoops\Core\FixedGroups;
 
 /**
  * XOOPS

--- a/htdocs/xoops_lib/Xoops.php
+++ b/htdocs/xoops_lib/Xoops.php
@@ -1004,7 +1004,7 @@ class Xoops
      *
      * @return  boolean
      */
-    public static function loadLocale($domain = null, $locale = null)
+    public static function loadLocale($domain = 'xoops', $locale = null)
     {
         return Xoops_Locale::loadLocale($domain, $locale);
     }

--- a/htdocs/xoops_lib/Xoops.php
+++ b/htdocs/xoops_lib/Xoops.php
@@ -1004,7 +1004,7 @@ class Xoops
      *
      * @return  boolean
      */
-    public static function loadLocale($domain = 'xoops', $locale = null)
+    public static function loadLocale($domain = null, $locale = null)
     {
         return Xoops_Locale::loadLocale($domain, $locale);
     }
@@ -1298,6 +1298,16 @@ class Xoops
         }
         $timestamp = $timestamp - (($userTZ - $this->getConfig('server_TZ')) * 3600);
         return (int)$timestamp;
+    }
+
+    /**
+     * @return array of groups the current user is associted with
+     */
+    public function getUserGroups()
+    {
+        $groups = $this->isUser() ? $this->user->getGroups() : array(FixedGroups::ANONYMOUS);
+
+        return $groups;
     }
 
     /**

--- a/htdocs/xoops_lib/Xoops/Core/FixedGroups.php
+++ b/htdocs/xoops_lib/Xoops/Core/FixedGroups.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ You may not change or alter any portion of this comment or credits
+ of supporting developers from this source code or any supporting source code
+ which is considered copyrighted (c) material of the original comment or credit authors.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+namespace Xoops\Core;
+
+/**
+ * FixedGroups provides constants for group ids that are fixed, and cannot be changed
+ *
+ * @category  Xoops\Core
+ * @package   FixedGroups
+ * @author    Richard Griffith <richard@geekwright.com>
+ * @copyright 2015 The XOOPS Project http://sourceforge.net/projects/xoops/
+ * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      http://xoops.org
+ */
+class FixedGroups
+{
+    const ADMIN     = 1;
+    const USERS     = 2;
+    const ANONYMOUS = 3;
+}

--- a/htdocs/xoops_lib/Xoops/Form/GroupPermissionForm.php
+++ b/htdocs/xoops_lib/Xoops/Form/GroupPermissionForm.php
@@ -11,6 +11,8 @@
 
 namespace Xoops\Form;
 
+use Xoops\Core\FixedGroups;
+
 /**
  * GroupPermmissionForm - a form for setting module specific group permissions
  *
@@ -137,7 +139,7 @@ class GroupPermissionForm extends Form
         $member_handler = $xoops->getHandlerMember();
         $glist = $member_handler->getGroupList();
         foreach (array_keys($glist) as $i) {
-            if ($i == XOOPS_GROUP_ANONYMOUS && !$this->showAnonymous) {
+            if ($i == FixedGroups::ANONYMOUS && !$this->showAnonymous) {
                 continue;
             }
             // get selected item id(s) for each group

--- a/htdocs/xoops_lib/Xoops/Form/SelectGroup.php
+++ b/htdocs/xoops_lib/Xoops/Form/SelectGroup.php
@@ -12,6 +12,7 @@
 namespace Xoops\Form;
 
 use Xoops\Core\Kernel\Criteria;
+use Xoops\Core\FixedGroups;
 
 /**
  * SelectGroup - a select field with a choice of available groups
@@ -41,7 +42,7 @@ class SelectGroup extends Select
         parent::__construct($caption, $name, $value, $size, $multiple);
         $member_handler = \Xoops::getInstance()->getHandlerMember();
         if (!$include_anon) {
-            $this->addOptionArray($member_handler->getGroupList(new Criteria('groupid', XOOPS_GROUP_ANONYMOUS, '!=')));
+            $this->addOptionArray($member_handler->getGroupList(new Criteria('groupid', FixedGroups::ANONYMOUS, '!=')));
         } else {
             $this->addOptionArray($member_handler->getGroupList());
         }

--- a/htdocs/xoops_lib/Xoops/Module/Helper/HelperAbstract.php
+++ b/htdocs/xoops_lib/Xoops/Module/Helper/HelperAbstract.php
@@ -10,6 +10,7 @@
  */
 
 namespace Xoops\Module\Helper;
+
 /**
  * @copyright       The XOOPS Project http://sourceforge.net/projects/xoops/
  * @license     GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
@@ -159,16 +160,6 @@ abstract class HelperAbstract
     }
 
     /**
-     * TODO - reevaluate this even existing here - this is not module
-     * related and we should have easy access to this (and similar)
-     * elsewhere (maybe a user helper?)
-     */
-    public function getUserGroups()
-    {
-        return $this->xoops()->isUser() ? $this->xoops()->user->getGroups() : XOOPS_GROUP_ANONYMOUS;
-    }
-
-    /**
      * Return absolute URL for a module relative URL
      *
      * @param string $url
@@ -229,8 +220,8 @@ abstract class HelperAbstract
     }
 
     /**
-     * @param null|XoopsObject       $obj
-     * @param string                 $name
+     * @param null|XoopsObject $obj
+     * @param string           $name
      *
      * @return \Xoops\Form\Form|boolean
      */

--- a/htdocs/xoops_lib/smarty/xoops_plugins/function.xoblock.php
+++ b/htdocs/xoops_lib/smarty/xoops_plugins/function.xoblock.php
@@ -64,7 +64,7 @@ function smarty_function_xoblock($params, &$smarty)
     } else {
         $blockObj = $block_objs[$block_id];
     }
-    $user_groups = $xoops->isUser() ? $xoops->user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+    $user_groups = $xoops->getUserGroups();
 
     static $allowed_blocks;
     if (count($allowed_blocks) == 0) {

--- a/tests/unit/xoopsLib/Xoops/Module/Helper/HelperAbstractTest.php
+++ b/tests/unit/xoopsLib/Xoops/Module/Helper/HelperAbstractTest.php
@@ -164,15 +164,6 @@ class Xoops_Module_Helper_AbstractTest extends \PHPUnit_Framework_TestCase
 		$this->markTestIncomplete();
     }
 
-	public function test_getUserGroups()
-	{
-		$class = $this->myClass;
-		$instance = $class::getInstance();
-
-		$x = $instance->getUserGroups();
-		$this->assertSame(XOOPS_GROUP_ANONYMOUS, $x);
-    }
-
     public function test_url()
 	{
 		$class = $this->myClass;

--- a/tests/unit/xoopsLib/XoopsTest.php
+++ b/tests/unit/xoopsLib/XoopsTest.php
@@ -743,6 +743,15 @@ class XoopsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_int($value));
     }
 
+    public function test_getUserGroups()
+    {
+        $instance = Xoops::getInstance();
+        unset($instance->user);
+        $actual = $instance->getUserGroups();
+        $expected = array(\Xoops\Core\FixedGroups::ANONYMOUS);
+        $this->assertSame($expected, $actual);
+    }
+
     public function test_makePass()
 	{
         $instance = Xoops::getInstance();


### PR DESCRIPTION
Remove XOOPS_GROUP_ADMIN, XOOPS_GROUP_USERS, and XOOPS_GROUP_ANONYMOUS defines replacing with FixedGroups static constants.

Implement a \Xoops getUserGroups() method to consolidate generating an array of the current user's groups, including Anonymous users.