### PR TITLE
Implement a FixedGroups::REMOVED user group

### DIFF
--- a/htdocs/include/checklogin.php
+++ b/htdocs/include/checklogin.php
@@ -52,6 +52,10 @@ if (false != $user) {
         $xoops->redirect($xoops_url . '/index.php', 5, XoopsLocale::E_SELECTED_USER_DEACTIVATED_OR_NOT_ACTIVE);
         exit();
     }
+    if (in_array(FixedGroups::REMOVED, $user->getGroups())) {
+        $xoops->redirect($xoops_url . '/index.php', 1, XoopsLocale::E_NO_ACCESS_PERMISSION);
+        exit();
+    }
     if ($xoops->getConfig('closesite') == 1) {
         $allowed = false;
         foreach ($user->getGroups() as $group) {

--- a/htdocs/modules/system/admin/groups/main.php
+++ b/htdocs/modules/system/admin/groups/main.php
@@ -93,7 +93,7 @@ switch ($op) {
             $edit_delete = '<a href="admin.php?fct=groups&amp;op=groups_edit&amp;groups_id=' . $groups_id . '">'
                 . '<img src="./images/icons/edit.png" border="0" alt="' . SystemLocale::EDIT_GROUP
                 . '" title="' . SystemLocale::EDIT_GROUP . '"></a>';
-            if (!in_array($group->getVar("groupid"), array(FixedGroups::ADMIN, FixedGroups::USERS, FixedGroups::ANONYMOUS))
+            if (!in_array($group->getVar("groupid"), array(FixedGroups::ADMIN, FixedGroups::USERS, FixedGroups::ANONYMOUS, FixedGroups::REMOVED))
             ) {
                 $groups['delete'] = 1;
                 $edit_delete .= '<a href="admin.php?fct=groups&amp;op=groups_delete&amp;groups_id=' . $groups_id . '">'

--- a/htdocs/modules/system/include/install.php
+++ b/htdocs/modules/system/include/install.php
@@ -33,8 +33,6 @@ use Xmf\Database\TableLoad;
 function xoops_module_install_system(XoopsModule $module)
 {
     $xoops = Xoops::getInstance();
-    // data for table 'group'
-    $group_handler = $xoops->getHandlerGroup();
 
     // load groups table
     $rows = array(

--- a/htdocs/modules/system/include/install.php
+++ b/htdocs/modules/system/include/install.php
@@ -9,6 +9,9 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
+use Xoops\Core\FixedGroups;
+use Xmf\Database\TableLoad;
+
 /**
  * System install module
  *
@@ -23,46 +26,51 @@
 /**
  * xoops_module_install_system - initialize on install
  *
- * @param type &$module module object
+ * @param XoopsModule $module module object
  *
  * @return void
  */
-function xoops_module_install_system(&$module)
+function xoops_module_install_system(XoopsModule $module)
 {
     $xoops = Xoops::getInstance();
     // data for table 'group'
     $group_handler = $xoops->getHandlerGroup();
-    // create admin group
-    $obj = $group_handler->create();
-    $obj->setVar("name", addslashes(SystemLocale::WEBMASTERS));
-    $obj->setVar("description", addslashes(SystemLocale::WEBMASTERS_OF_THIS_SITE));
-    $obj->setVar("group_type", 'Admin');
-    if (!$group_handler->insert($obj)) {
-        echo $xoops->alert('error', $obj->getHtmlErrors());
-    }
-    // create registered users group
-    $obj = $group_handler->create();
-    $obj->setVar("name", addslashes(SystemLocale::REGISTERED_USERS));
-    $obj->setVar("description", addslashes(SystemLocale::REGISTERED_USERS_GROUP));
-    $obj->setVar("group_type", 'User');
-    if (!$group_handler->insert($obj)) {
-        echo $xoops->alert('error', $obj->getHtmlErrors());
-    }
-    // create anonymous users group
-    $obj = $group_handler->create();
-    $obj->setVar("name", addslashes(SystemLocale::ANONYMOUS_USERS));
-    $obj->setVar("description", addslashes(SystemLocale::ANONYMOUS_USERS_GROUP));
-    $obj->setVar("group_type", 'Anonymous');
-    if (!$group_handler->insert($obj)) {
-        echo $xoops->alert('error', $obj->getHtmlErrors());
-    }
-    // data for table 'groups_users_link'
+
+    // load groups table
+    $rows = array(
+        array(
+            'groupid' => FixedGroups::ADMIN,
+            'name' => SystemLocale::WEBMASTERS,
+            'description' => SystemLocale::WEBMASTERS_OF_THIS_SITE,
+            'group_type' => 'Admin',
+        ),
+        array(
+            'groupid' => FixedGroups::USERS,
+            'name' => SystemLocale::REGISTERED_USERS,
+            'description' => SystemLocale::REGISTERED_USERS_GROUP,
+            'group_type' => 'Admin',
+        ),
+        array(
+            'groupid' => FixedGroups::ANONYMOUS,
+            'name' => SystemLocale::ANONYMOUS_USERS,
+            'description' => SystemLocale::ANONYMOUS_USERS_GROUP,
+            'group_type' => 'Admin',
+        ),
+        array(
+            'groupid' => FixedGroups::REMOVED,
+            'name' => SystemLocale::REMOVED_USERS,
+            'description' => SystemLocale::REMOVED_USERS_GROUP,
+            'group_type' => 'Removed',
+        ),
+    );
+    TableLoad::loadTableFromArray('groups', $rows);
 
     // data for table 'group_permission'
     $groupperm_handler = $xoops->getHandlerGroupPerm();
-    for ($i = 2; $i <= 3; ++$i) {
+    $allGroups = array(FixedGroups::USERS, FixedGroups::ANONYMOUS);
+    foreach ($allGroups as $gid) {
         $obj = $groupperm_handler->create();
-        $obj->setVar("gperm_groupid", $i);
+        $obj->setVar("gperm_groupid", $gid);
         $obj->setVar("gperm_itemid", '1');
         $obj->setVar("gperm_modid", '1');
         $obj->setVar("gperm_name", 'module_read');
@@ -70,16 +78,7 @@ function xoops_module_install_system(&$module)
             echo $xoops->alert('error', $obj->getHtmlErrors());
         }
     }
-    for ($i = 1; $i <= 17; ++$i) {
-        $obj = $groupperm_handler->create();
-        $obj->setVar("gperm_groupid", '1');
-        $obj->setVar("gperm_itemid", $i);
-        $obj->setVar("gperm_modid", '1');
-        $obj->setVar("gperm_name", 'module_read');
-        if (!$groupperm_handler->insert($obj)) {
-            echo $xoops->alert('error', $obj->getHtmlErrors());
-        }
-    }
+
     // Make system block visible
     $blockmodulelink_handler = $xoops->getHandlerBlockmodulelink();
     $block_handler = new XoopsBlockHandler($xoops->db());
@@ -125,8 +124,8 @@ function xoops_module_install_system(&$module)
 
     // data for table 'groups_users_link'
     $types = array(\PDO::PARAM_INT, \PDO::PARAM_INT);
-    $data = array('groupid' => 1, 'uid' => 1);
+    $data = array('groupid' => FixedGroups::ADMIN, 'uid' => 1);
     $xoops->db()->insertPrefix('groups_users_link', $data, $types);
-    $data = array('groupid' => 2, 'uid' => 1);
+    $data = array('groupid' => FixedGroups::USERS, 'uid' => 1);
     $xoops->db()->insertPrefix('groups_users_link', $data, $types);
 }

--- a/htdocs/modules/system/locale/en_US/en_US.php
+++ b/htdocs/modules/system/locale/en_US/en_US.php
@@ -368,6 +368,8 @@ By clicking Register below you agree to be bound by these conditions.";
     const REGISTERED_USERS_GROUP = "Registered users group";
     const REGISTRATION_DATE_GREATER_THAN_X = "Joined date is more than <span style='color:#ff0000;'>X</span> days ago";
     const REGISTRATION_DATE_LESS_THAN_X = "Joined date is less than <span style='color:#ff0000;'>X</span> days ago";
+    const REMOVED_USERS = "Removed users";
+    const REMOVED_USERS_GROUP = "Removed/Banned users group";
     const SCREENSHOT_IMAGE_WIDTH = "Screenshot image width";
     const SECURE_LOGIN = "Secure login";
     const SERVICES_DESC = "From here you can manage service<br />providers and priorities.";

--- a/htdocs/xoops_lib/Xoops/Core/FixedGroups.php
+++ b/htdocs/xoops_lib/Xoops/Core/FixedGroups.php
@@ -26,4 +26,5 @@ class FixedGroups
     const ADMIN     = 1;
     const USERS     = 2;
     const ANONYMOUS = 3;
+    const REMOVED   = 4;
 }


### PR DESCRIPTION
Adding a user to the REMOVED group prevents login, but retains other user info.

This is was originally requested as BANNED in #323, but REMOVED is a more general term, useful in non-social situations as well.