### PR TITLE
Add getRandomObject() method to Xoops\Core\Kernel\Model\Read

### DIFF
--- a/htdocs/xoops_lib/Xoops/Core/Kernel/Model/Read.php
+++ b/htdocs/xoops_lib/Xoops/Core/Kernel/Model/Read.php
@@ -20,7 +20,7 @@ use Xoops\Core\Kernel\XoopsModelAbstract;
  * @category  Xoops\Core\Kernel\Model\Read
  * @package   Xoops\Core\Kernel
  * @author    Taiwen Jiang <phppp@users.sourceforge.net>
- * @copyright 2000-2013 XOOPS Project (http://xoops.org)
+ * @copyright 2000-2015 XOOPS Project (http://xoops.org)
  * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
  * @link      http://xoops.org
  * @since     2.3.0
@@ -183,5 +183,40 @@ class Read extends XoopsModelAbstract
             $ret[] = $myrow[$this->handler->keyName];
         }
         return $ret;
+    }
+
+    /**
+     * getRandomObject - return a randomly selected object
+     *
+     * @param CriteriaElement|null $criteria {@link CriteriaElement} with conditions to meet
+     *
+     * @return XoopsObject|null {@link XoopsObject}
+     */
+    public function getRandomObject(CriteriaElement $criteria = null)
+    {
+        $qb = $this->handler->db2->createXoopsQueryBuilder();
+        $qb ->select('COUNT(*)')
+            ->from($this->handler->table, null);
+        if (null !== $criteria) {
+            $qb = $criteria->renderQb($qb);
+        }
+        $result = $qb->execute();
+        $count = $result->fetchColumn();
+
+        $offset = mt_rand(0, $count - 1);
+
+        $qb = $this->handler->db2->createXoopsQueryBuilder();
+        $qb ->select($this->handler->keyName)
+            ->from($this->handler->table, null);
+        if (null !== $criteria) {
+            $qb = $criteria->renderQb($qb);
+        }
+        $qb ->setFirstResult($offset)
+            ->setMaxResults(1);
+
+        $result = $qb->execute();
+        $randomKey = $result->fetchColumn();
+
+        return $this->handler->get($randomKey);
     }
 }

--- a/htdocs/xoops_lib/Xoops/Core/Kernel/Model/Sync.php
+++ b/htdocs/xoops_lib/Xoops/Core/Kernel/Model/Sync.php
@@ -33,7 +33,7 @@ use Xoops\Core\Kernel\XoopsModelAbstract;
  * @category  Xoops\Core\Kernel\Model\Sync
  * @package   Xoops\Core\Kernel
  * @author    Taiwen Jiang <phppp@users.sourceforge.net>
- * @copyright 2000-2013 XOOPS Project (http://xoops.org)
+ * @copyright 2000-2015 XOOPS Project (http://xoops.org)
  * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
  * @link      http://xoops.org
  * @since     2.3.0
@@ -41,11 +41,14 @@ use Xoops\Core\Kernel\XoopsModelAbstract;
 class Sync extends XoopsModelAbstract
 {
     /**
-     * Clean orphan objects against linked objects
+     * Clean orphan objects in this handler (child table) that are not in parent table
      *
-     * @param string $table_link   table of linked object for JOIN; deprecated, for backward compat
-     * @param string $field_link   field of linked object for JOIN; deprecated, for backward compat
-     * @param string $field_object field of current object for JOIN; deprecated, for backward compat
+     * The parameters can be defined in the handler. Naming should be updated to reflect
+     * standard relational terminology.
+     *
+     * @param string $table_link   parent table
+     * @param string $field_link   primary key (parent table)
+     * @param string $field_object foreign key (child table)
      *
      * @return bool true on success
      */

--- a/htdocs/xoops_lib/Xoops/Core/Kernel/XoopsPersistableObjectHandler.php
+++ b/htdocs/xoops_lib/Xoops/Core/Kernel/XoopsPersistableObjectHandler.php
@@ -13,6 +13,7 @@ namespace Xoops\Core\Kernel;
 use Xoops\Core\Database\Connection;
 use Xoops\Core\Kernel\CriteriaElement;
 use Xoops\Core\Kernel\XoopsModelFactory;
+use Xoops\Core\Kernel\XoopsObject;
 use Xoops\Core\Kernel\XoopsObjectHandler;
 
 /**
@@ -22,7 +23,7 @@ use Xoops\Core\Kernel\XoopsObjectHandler;
  * @package   Xoops\Core\Kernel
  * @author    Taiwen Jiang <phppp@users.sourceforge.net>
  * @author    Jan Keller Pedersen <mithrandir@xoops.org>
- * @copyright 2000-2013 XOOPS Project (http://xoops.org)
+ * @copyright 2000-2015 XOOPS Project (http://xoops.org)
  * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
  * @link      http://xoops.org
  * @since     2.0.0
@@ -217,7 +218,9 @@ abstract class XoopsPersistableObjectHandler extends XoopsObjectHandler
      */
     public function create($isNew = true)
     {
-		if (empty($this->className)) return false;
+        if (empty($this->className)) {
+            return false;
+        }
 
         /* @var $obj XoopsObject */
         $obj = new $this->className();
@@ -327,7 +330,9 @@ abstract class XoopsPersistableObjectHandler extends XoopsObjectHandler
      */
     public function deleteAll(CriteriaElement $criteria, $force = true, $asObject = false)
     {
-		if (empty($criteria)) return false;
+        if (empty($criteria)) {
+            return false;
+        }
 
         /* @var $handler XoopsModelWrite */
         $handler = $this->loadHandler('write');
@@ -346,7 +351,9 @@ abstract class XoopsPersistableObjectHandler extends XoopsObjectHandler
      */
     public function updateAll($fieldname, $fieldvalue, CriteriaElement $criteria, $force = false)
     {
-		if (empty($criteria)) return false;
+        if (empty($criteria)) {
+            return false;
+        }
 
         /* @var $handler XoopsModelWrite */
         $handler = $this->loadHandler('write');
@@ -354,11 +361,6 @@ abstract class XoopsPersistableObjectHandler extends XoopsObjectHandler
     }
 
     /**
-     * *#@-
-     */
-
-    /**
-     * *#@+
      * Methods of read handler {@link XoopsObjectRead}
      */
 
@@ -430,13 +432,9 @@ abstract class XoopsPersistableObjectHandler extends XoopsObjectHandler
     }
 
     /**
-     * *#@-
-     */
-
-    /**
-     * *#@+
      * Methods of stats handler {@link XoopsObjectStats}
      */
+
     /**
      * count objects matching a condition
      *
@@ -466,13 +464,9 @@ abstract class XoopsPersistableObjectHandler extends XoopsObjectHandler
     }
 
     /**
-     * *#@-
-     */
-
-    /**
-     * *#@+
      * Methods of joint handler {@link XoopsObjectJoint}
      */
+
     /**
      * get a list of objects matching a condition joint with another related object
      *
@@ -559,13 +553,9 @@ abstract class XoopsPersistableObjectHandler extends XoopsObjectHandler
     }
 
     /**
-     * *#@-
-     */
-
-    /**
-     * *#@+
      * Methods of sync handler {@link XoopsObjectSync}
      */
+
     /**
      * Clean orphan objects against linked objects
      *
@@ -586,6 +576,10 @@ abstract class XoopsPersistableObjectHandler extends XoopsObjectHandler
     /**
      * Synchronizing objects
      *
+     * @param string $table_link   parent table
+     * @param string $field_link   primary key (parent table)
+     * @param string $field_object foreign key (child table)
+     *
      * @return bool true on success
      */
     public function synchronization($table_link = '', $field_link = '', $field_object = '')
@@ -593,7 +587,4 @@ abstract class XoopsPersistableObjectHandler extends XoopsObjectHandler
         $retval = $this->cleanOrphan($table_link, $field_link, $field_object);
         return $retval;
     }
-    /**
-     * *#@-
-     */
 }

--- a/tests/unit/xoopsLib/Xoops/Core/Kernel/Model/ReadTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/Kernel/Model/ReadTest.php
@@ -8,90 +8,103 @@ require_once(dirname(__FILE__).'/../../../../../init_new.php');
 */
 class ReadTest extends \PHPUnit_Framework_TestCase
 {
-	protected $conn = null;
-	
-	protected $myClass = 'Xoops\Core\Kernel\Model\Read';
-	protected $myAbstractClass = 'Xoops\Core\Kernel\XoopsModelAbstract';
-	
+    protected $conn = null;
+
+    protected $myClass = 'Xoops\Core\Kernel\Model\Read';
+    protected $myAbstractClass = 'Xoops\Core\Kernel\XoopsModelAbstract';
+
     public function setUp()
-	{
-		$db = XoopsDatabaseFactory::getDatabaseConnection();
-		$this->conn = $db->conn;
+    {
+        $db = XoopsDatabaseFactory::getDatabaseConnection();
+        $this->conn = $db->conn;
     }
 
     public function test___construct()
-	{
+    {
         $instance=new $this->myClass();
         $this->assertInstanceOf($this->myClass, $instance);
         $this->assertInstanceOf($this->myAbstractClass, $instance);
-	}
-	
-	public function test_getAll()
-	{
-        $instance=new $this->myClass();
-        $this->assertinstanceOf($this->myClass, $instance);
-		
-		$handler = new XoopsGroupHandler($this->conn);
-		$result = $instance->setHandler($handler);
-		$this->assertTrue($result);
-		
-		$values=$instance->getAll();
-		$this->assertTrue(is_array($values));
-		$this->assertTrue(count($values) >= 0);
-		if (!empty($values[1])) {
-			$this->assertInstanceOf('XoopsGroup', $values[1]);
-		}
     }
-	
-	public function test_getObjects()
-	{
+
+    public function test_getAll()
+    {
         $instance=new $this->myClass();
         $this->assertinstanceOf($this->myClass, $instance);
-		
-		$handler = new XoopsGroupHandler($this->conn);
-		$result = $instance->setHandler($handler);
-		$this->assertTrue($result);
-		
-		$values=$instance->getObjects();
-		$this->assertTrue(is_array($values));
-		$this->assertTrue(count($values) >= 0);
-		if (!empty($values[1])) {
-			$this->assertInstanceOf('XoopsGroup', $values[1]);
-		}
+
+        $handler = new XoopsGroupHandler($this->conn);
+        $result = $instance->setHandler($handler);
+        $this->assertTrue($result);
+
+        $values=$instance->getAll();
+        $this->assertTrue(is_array($values));
+        $this->assertTrue(count($values) >= 0);
+        if (!empty($values[1])) {
+            $this->assertInstanceOf('XoopsGroup', $values[1]);
+        }
     }
-	
-	public function test_getList()
-	{
+
+    public function test_getObjects()
+    {
         $instance=new $this->myClass();
         $this->assertinstanceOf($this->myClass, $instance);
-		
-		$handler = new XoopsGroupHandler($this->conn);
-		$result = $instance->setHandler($handler);
-		$this->assertTrue($result);
-		
-		$values=$instance->getList();
-		$this->assertTrue(is_array($values));
-		$this->assertTrue(count($values) >= 0);
-		if (!empty($values[1])) {
-			$this->assertTrue(is_string($values[1]));
-		}
+
+        $handler = new XoopsGroupHandler($this->conn);
+        $result = $instance->setHandler($handler);
+        $this->assertTrue($result);
+
+        $values=$instance->getObjects();
+        $this->assertTrue(is_array($values));
+        $this->assertTrue(count($values) >= 0);
+        if (!empty($values[1])) {
+            $this->assertInstanceOf('XoopsGroup', $values[1]);
+        }
     }
-	
-	public function test_getIds()
-	{
+
+    public function test_getList()
+    {
         $instance=new $this->myClass();
         $this->assertinstanceOf($this->myClass, $instance);
-		
-		$handler = new XoopsGroupHandler($this->conn);
-		$result = $instance->setHandler($handler);
-		$this->assertTrue($result);
-		
-		$values=$instance->getIds();
-		$this->assertTrue(is_array($values));
-		$this->assertTrue(count($values) >= 0);
-		if (!empty($values[1])) {
-			$this->assertTrue(is_string($values[1]));
-			$this->assertTrue(intval($values[1]) >= 0);
-		}
+
+        $handler = new XoopsGroupHandler($this->conn);
+        $result = $instance->setHandler($handler);
+        $this->assertTrue($result);
+
+        $values=$instance->getList();
+        $this->assertTrue(is_array($values));
+        $this->assertTrue(count($values) >= 0);
+        if (!empty($values[1])) {
+            $this->assertTrue(is_string($values[1]));
+        }
+    }
+
+    public function test_getIds()
+    {
+        $instance=new $this->myClass();
+        $this->assertinstanceOf($this->myClass, $instance);
+
+        $handler = new XoopsGroupHandler($this->conn);
+        $result = $instance->setHandler($handler);
+        $this->assertTrue($result);
+
+        $values=$instance->getIds();
+        $this->assertTrue(is_array($values));
+        $this->assertTrue(count($values) >= 0);
+        if (!empty($values[1])) {
+            $this->assertTrue(is_string($values[1]));
+            $this->assertTrue(intval($values[1]) >= 0);
+        }
+    }
+
+    public function test_getRandomObject()
+    {
+        $instance=new $this->myClass();
+        $this->assertinstanceOf($this->myClass, $instance);
+
+        $handler = new XoopsGroupHandler($this->conn);
+        $result = $instance->setHandler($handler);
+        $this->assertTrue($result);
+
+        $values=$instance->getRandomObject();
+        $this->assertInstanceOf('XoopsGroup', $values);
     }
 }

--- a/tests/unit/xoopsLib/Xoops/Core/Kernel/Model/SyncTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/Kernel/Model/SyncTest.php
@@ -10,42 +10,41 @@ use Xoops\Core\Kernel\Model\Sync;
 */
 class SyncTest extends \PHPUnit_Framework_TestCase
 {
-	protected $conn = null;
-	
-	protected $myClass = 'Xoops\Core\Kernel\Model\Sync';
-	protected $myAbstractClass = 'Xoops\Core\Kernel\XoopsModelAbstract';
+    protected $conn = null;
+
+    protected $myClass = 'Xoops\Core\Kernel\Model\Sync';
+    protected $myAbstractClass = 'Xoops\Core\Kernel\XoopsModelAbstract';
 
     public function setUp()
-	{
-		$db = XoopsDatabaseFactory::getDatabaseConnection();
-		$this->conn = $db->conn;
+    {
+        $db = XoopsDatabaseFactory::getDatabaseConnection();
+        $this->conn = $db->conn;
     }
 
     public function test___construct()
-	{
+    {
         $instance=new $this->myClass();
         $this->assertInstanceOf($this->myClass, $instance);
         $this->assertInstanceOf($this->myAbstractClass, $instance);
-	}
-	
-	public function test_cleanOrphan()
-	{
-        $instance=new $this->myClass();
-        $this->assertinstanceOf($this->myClass, $instance);
-		
-		$handler = new XoopsGroupHandler($this->conn);
-		$result = $instance->setHandler($handler);
-		$this->assertTrue($result);
-		
-        $db = XoopsDatabaseFactory::getDatabaseConnection();
-		$handler->table_link=$db->prefix('groups_users_link');
-		$handler->field_link='groupid';
-		$handler->field_object=$handler->field_link;
-		
-		$values=$instance->cleanOrphan();
-		$this->assertTrue(is_int($values));
-		$this->assertTrue($values == 0);
-		
     }
 
+    public function test_cleanOrphan()
+    {
+        $instance=new $this->myClass();
+        $this->assertinstanceOf($this->myClass, $instance);
+
+        $handler = new XoopsMembershipHandler($this->conn);
+        $result = $instance->setHandler($handler);
+        $this->assertTrue($result);
+
+        $db = XoopsDatabaseFactory::getDatabaseConnection();
+        $handler->table_link=$db->prefix('groups');
+        $handler->field_link='groupid';
+        $handler->field_object='groupid';
+
+        $values=$instance->cleanOrphan();
+        $this->assertTrue(is_int($values));
+        $this->assertTrue($values == 0);
+
+    }
 }


### PR DESCRIPTION
New method retrives a single random object using cross database portable algorithm, with optional Criteria. Example usage: 
```$object = $handler->getRandomObject($criteria);```

Also:
- Add test for new method
- Fix Model\Sync test to not delete groups with no members (parent and child relationship was backwards) Now enforces foreign key constraint on groups_users_link table, using groups table as parent.
- Add some comments to Model\Sync identifying parent and child tables and foreign key by common names
- Minor cleanups in XoopsPersistableObjectHandler