### PR TITLE
Update min_db logic in module admin

### DIFF
--- a/htdocs/locale/en_US/en_US.php
+++ b/htdocs/locale/en_US/en_US.php
@@ -229,6 +229,7 @@ class XoopsLocaleEn_US extends Xoops_Locale_Abstract
     const EF_CLASS_NOT_FOUND = "Class '%s' was not found!";
     const EF_CORRESPONDING_USER_NOT_FOUND_IN_DATABASE = "No corresponding user information has been found in the XOOPS database for connection: %s!";
     const EF_DATABASE_ERROR = "Database error: %s";
+    const EF_DATABASE_NOT_SUPPORTED = "This module does not support the current database platform (%s)";
     const EF_DIRECTORY_EXISTS = "Directory '%s' exists on your server!";
     const EF_DIRECTORY_NOT_OPENED = "Directory '%s' was not opened!";
     const EF_DIRECTORY_WITH_WRITE_PERMISSION_NOT_OPENED = "Directory with write permission '%s' was not opened!";

--- a/htdocs/modules/maintenance/xoops_version.php
+++ b/htdocs/modules/maintenance/xoops_version.php
@@ -46,7 +46,7 @@ $modversion['module_website_name'] = 'XOOPS';
 $modversion['module_status']       = 'ALPHA';
 $modversion['min_php']             = '5.3.7';
 $modversion['min_xoops']           = '2.6.0';
-$modversion['min_db']              = array('mysql' => '5.0.7', 'mysqli' => '5.0.7');
+$modversion['min_db']              = array('mysql' => '5.0.7'); // table maintenance and dump functions are MySQL only!
 
 // paypal
 $modversion['paypal']                  = array();

--- a/htdocs/modules/page/xoops_version.php
+++ b/htdocs/modules/page/xoops_version.php
@@ -40,7 +40,6 @@ $modversion['module_website_name'] = 'XOOPS';
 $modversion['module_status']       = 'Alpha';
 $modversion['min_php']             = '5.3.7';
 $modversion['min_xoops']           = '2.6.0';
-$modversion['min_db']              = array('mysql' => '5.0.7', 'mysqli' => '5.0.7');
 
 // paypal
 $modversion['paypal']                  = array();

--- a/htdocs/modules/protector/xoops_version.php
+++ b/htdocs/modules/protector/xoops_version.php
@@ -44,7 +44,7 @@ $modversion["module_website_name"] = "XOOPS";
 $modversion["module_status"]       = "RC";
 $modversion['min_php']             = '5.3.7';
 $modversion['min_xoops']           = "2.6.0";
-$modversion['min_db']              = array('mysql' => '5.0.7', 'mysqli' => '5.0.7');
+$modversion['min_db']              = array('mysql' => '5.0.7'); // currently MySQL only
 
 /*
  Admin menu

--- a/htdocs/xoops_lib/Xoops/Module/Admin.php
+++ b/htdocs/xoops_lib/Xoops/Module/Admin.php
@@ -434,7 +434,7 @@ class Admin
 
         // If you use a config label
         if ($this->module->getInfo('min_php') || $this->module->getInfo('min_xoops')
-            || !empty($this->itemConfigBoxLine)
+            || $this->module->getInfo('min_db') || !empty($this->itemConfigBoxLine)
         ) {
             // PHP version
             if ($this->module->getInfo('min_php')) {
@@ -479,7 +479,7 @@ class Admin
 
             $dbarray = $this->module->getInfo('min_db');
             if ($dbarray !== false) {
-                $dbCurrentPlatform = '.'.$xoops->db()->getDatabasePlatform()->getName();
+                $dbCurrentPlatform = $xoops->db()->getDatabasePlatform()->getName();
                 $dbCurrentVersion  = $xoops->db()->getWrappedConnection()->getServerVersion();
                 if (isset($dbarray[$dbCurrentPlatform])) {
                     $dbRequiredVersion = $dbarray[$dbCurrentPlatform];
@@ -514,7 +514,8 @@ class Admin
             // xoops version
             if ($this->module->getInfo('min_xoops')) {
                 $xoopsVersion = substr(\Xoops::VERSION, 6); // skip 'XOOPS ' prefix
-                if (version_compare($xoopsVersion, $this->module->getInfo('min_xoops')) >= 0) {
+                $xoopsCmpVersion = str_ireplace(['Alpha', 'Beta', 'RC'], ['0Alpha', '0Beta', '0RC'], $xoopsVersion);
+                if (0 >= version_compare($xoopsCmpVersion, $this->module->getInfo('min_xoops'))) {
                     $this->addConfigBoxLine(
                         sprintf(
                             \XoopsLocale::F_MINIMUM_XOOPS_VERSION_REQUIRED,


### PR DESCRIPTION
Handling of min_db was using database driver specific calls which caused issues as mentioned in #367.

This PR switches that logic to use Doctrine DBAL connection and platform functions. Also, includes a few other small fixes.

**NB**: if *min_db* is specified in a module's *xoops_version.php*, and the current platform is not in the array, an error message will be shown. In general, do NOT specify min_db unless database specific commands are required (i.e. OPTIMIZE on MySQL.) If you are using XoopsPersistableObject (and even custom query builder selects) you can let Xoops and Doctrine DBAL do the version limiting for you.