### PR TITLE
Fixes for 387 and 395

### DIFF
--- a/htdocs/class/xoopseditor/tinymce4/include/xoopsimagemanager.php
+++ b/htdocs/class/xoopseditor/tinymce4/include/xoopsimagemanager.php
@@ -1,1 +1,23 @@
-<?php/** *  TinyMCE adapter for XOOPS * * @copyright       XOOPS Project (http://xoops.org) * @license         GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html) * @package         class * @subpackage      editor * @since           2.3.0 * @author          Laurent JEN <dugris@frxoops.org> * @version         $Id: xoopsimagemanager.php 8066 2011-11-06 05:09:33Z beckmi $ */// check categories readability by group$groups = is_object( $GLOBALS["xoopsUser"] ) ? $GLOBALS["xoopsUser"]->getGroups() : array( XOOPS_GROUP_ANONYMOUS );$imgcat_handler =& xoops_gethandler('imagecategory');if ( count($imgcat_handler->getList($groups, 'imgcat_read', 1)) == 0 ) {    return false;}return true;?>
+<?php
+
+use Xoops\Core\FixedGroups;
+
+/**
+ *  TinyMCE adapter for XOOPS
+ *
+ * @copyright       XOOPS Project (http://xoops.org)
+ * @license         GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @package         class
+ * @subpackage      editor
+ * @since           2.3.0
+ * @author          Laurent JEN <dugris@frxoops.org>
+ * @version         $Id: xoopsimagemanager.php 8066 2011-11-06 05:09:33Z beckmi $
+ */
+
+// check categories readability by group
+$groups = is_object($GLOBALS["xoopsUser"]) ? $GLOBALS["xoopsUser"]->getGroups() : array(FixedGroups::ANONYMOUS );
+$imgcat_handler =& xoops_gethandler('imagecategory');
+if (count($imgcat_handler->getList($groups, 'imgcat_read', 1)) == 0) {
+    return false;
+}
+return true;

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -54,7 +54,7 @@ if ($xoops->isActiveModule($xoops->getConfig('startpage'))) {
         }
         $xoops->userIsAdmin = $xoops->user->isAdmin($xoops->module->getVar('mid'));
     } else {
-        if (!$moduleperm_handler->checkRight('module_read', $xoops->module->getVar('mid'), XOOPS_GROUP_ANONYMOUS)) {
+        if (!$moduleperm_handler->checkRight('module_read', $xoops->module->getVar('mid'), FixedGroups::ANONYMOUS)) {
             $xoops->redirect(\XoopsBaseConfig::get('url') . "/user.php", 1, XoopsLocale::E_NO_ACCESS_PERMISSION);
         }
     }

--- a/htdocs/install/include/config.php
+++ b/htdocs/install/include/config.php
@@ -151,6 +151,7 @@ $configs['extensions'] = array(
 
 // Writable files and directories
 $configs['writable'] = array(
+    'assets/',
     'uploads/',
 //  'uploads/avatars/',
     'uploads/images/',


### PR DESCRIPTION
Seem to have picked up a couple of references to the old
XOOPS_GROUP_ANONYMOUS define. This was causing the anonymous
access failure for a redirected start page #395

Also added assets to the list of directory that must be
writeable shown in the installer #387 