### PR TITLE
Add Smarty function for adding base assets

### DIFF
--- a/htdocs/modules/comments/templates/comments_nest.tpl
+++ b/htdocs/modules/comments/templates/comments_nest.tpl
@@ -1,4 +1,4 @@
-<{section name=i loop=$comments}>
+<{section name=i loop=$comments|default:[]}>
 <br/>
 <table cellspacing="1" class="outer">
     <tr>

--- a/htdocs/modules/comments/templates/comments_thread.tpl
+++ b/htdocs/modules/comments/templates/comments_thread.tpl
@@ -1,4 +1,4 @@
-<{section name=i loop=$comments}>
+<{section name=i loop=$comments|default:[]}>
 <br/>
 <table cellspacing="1" class="outer">
     <tr>

--- a/htdocs/modules/publisher/templates/blocks/publisher_latest_news.tpl
+++ b/htdocs/modules/publisher/templates/blocks/publisher_latest_news.tpl
@@ -11,7 +11,7 @@
 
 <{if $block.template == 'extended'}>
 
-<{php}>global $xoTheme;$xoTheme->addStylesheet(PUBLISHER_URL . '/css/publisher.css');<{/php}>
+<{addBaseStylesheet assets='modules/publisher/css/publisher.css' }>
 
 <{if $block.latestnews_scroll }>
 <marquee behavior='scroll' align='center' direction='<{$block.scrolldir}>' height='<{$block.scrollheight}>' scrollamount='3' scrolldelay='<{$block.scrollspeed}>' onmouseover='this.stop()' onmouseout='this.start()'>
@@ -65,7 +65,7 @@
 
 <{if $block.template == 'slider1'}>
 
-<{php}>global $xoTheme;$xoTheme->addScript('media/jquery/jquery.js');$xoTheme->addStylesheet(PUBLISHER_URL . '/css/publisher.css');<{/php}>
+<{addBaseScript assets='@jquery'}>
 
 <script type="text/javascript">
     jQuery(document).ready(function()
@@ -145,7 +145,7 @@
     }
 </script>
 
-<{section name=i}>
+<{section name=i loop=1}>
 
 <ul class="pub_slideshow1">
     <{foreach item=item from=$block.columns[i]}>
@@ -158,8 +158,8 @@
 <{/if}>
 
 <{if $block.template == 'slider2'}>
-
-<{php}>global $xoTheme;$xoTheme->addScript('media/jquery/jquery.js');$xoTheme->addStylesheet(PUBLISHER_URL . '/css/publisher.css');$xoTheme->addScript(PUBLISHER_URL . '/js/jquery.easing.js');$xoTheme->addScript(PUBLISHER_URL . '/js/script.easing.js');<{/php}>
+    <{addBaseScript assets='@jquery'}>
+    <{addBaseStylesheet assets='modules/publisher/css/publisher.css' }>
 
 <script type="text/javascript">
     jQuery(document).ready(function()
@@ -172,7 +172,7 @@
 
 </script>
 
-<{section name=i}>
+<{section name=i loop=1}>
 <div id="lofslidecontent45" class="lof-slidecontent">
 
     <div class="lof-main-outer">

--- a/htdocs/modules/publisher/templates/publisher_categories_table.tpl
+++ b/htdocs/modules/publisher/templates/publisher_categories_table.tpl
@@ -36,7 +36,7 @@
         <td class="even" align="right"><{$category.last_title_link|default:''}></td>
         <{/if}>
     </tr>
-    <{if $category.subcats}> <{foreach item=subcat from=$category.subcats}>
+    <{if $category.subcats|default:false}> <{foreach item=subcat from=$category.subcats}>
     <tr>
         <td class="odd" align="left">
             <div style="padding-left: 10px;">

--- a/htdocs/xoops_lib/smarty/xoops_plugins/function.addBaseScript.php
+++ b/htdocs/xoops_lib/smarty/xoops_plugins/function.addBaseScript.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * XOOPS addBaseScriptAsset() via Smarty template
+ *
+ * @copyright   2015 XOOPS Project (http://xoops.org)
+ * @license     GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @author      Richard Griffith <richard@geekwright.com>
+ */
+
+/**
+ * Add one or more scripts to the base script asset
+ *
+ * @param string                   $params commas separated list of script assets
+ * @param Smarty_Internal_Template $smarty passed by smarty
+ *
+ * @return string
+ */
+function smarty_function_addBaseScriptAssets($params, Smarty_Internal_Template $smarty)
+{
+    $xoops = Xoops::getInstance();
+    $assets = [];
+    if (isset($params['assets'])) {
+        $assets = explode(',', $params['assets']);
+    }
+    if (!empty($assets)) {
+        $xoops->theme()->addBaseScriptAssets($assets);
+    }
+    return '';
+}

--- a/htdocs/xoops_lib/smarty/xoops_plugins/function.addBaseScript.php
+++ b/htdocs/xoops_lib/smarty/xoops_plugins/function.addBaseScript.php
@@ -15,7 +15,7 @@
  *
  * @return string
  */
-function smarty_function_addBaseScriptAssets($params, Smarty_Internal_Template $smarty)
+function smarty_function_addBaseScript($params, Smarty_Internal_Template $smarty)
 {
     $xoops = Xoops::getInstance();
     $assets = [];

--- a/htdocs/xoops_lib/smarty/xoops_plugins/function.addBaseStylesheet.php
+++ b/htdocs/xoops_lib/smarty/xoops_plugins/function.addBaseStylesheet.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * XOOPS addBaseStylesheetAssets() via Smarty template
+ *
+ * @copyright   2015 XOOPS Project (http://xoops.org)
+ * @license     GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @author      Richard Griffith <richard@geekwright.com>
+ */
+
+/**
+ * Add one or more stylesheets to the base stylesheet asset
+ *
+ * @param string                   $params commas separated list of script assets
+ * @param Smarty_Internal_Template $smarty passed by smarty
+ *
+ * @return string
+ */
+function smarty_function_addBaseStylesheet($params, Smarty_Internal_Template $smarty)
+{
+    $xoops = Xoops::getInstance();
+    $assets = [];
+    if (isset($params['assets'])) {
+        $assets = explode(',', $params['assets']);
+    }
+    if (!empty($assets)) {
+        $xoops->theme()->addBaseStylesheetAssets($assets);
+    }
+    return '';
+}


### PR DESCRIPTION
Replace `<{php}>` tag use with functions
- `<{addBaseScript assets='path/filename.js' }>`
- `<{addBaseStylesheet assets='path/filename.css }>`

Fixes to two publisher templates