### PR TITLE
Xoops, Events and Session cleanup and fixes

### DIFF
--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -71,7 +71,7 @@ $xoopsLogger = $xoops->logger();
 /**
  * initialize events
  */
-$xoops->events()->initializeListeners();
+$xoops->events();
 
 $psr4loader = new \Xoops\Core\Psr4ClassLoader();
 $psr4loader->register();

--- a/htdocs/modules/debugbar/class/debugbarlogger.php
+++ b/htdocs/modules/debugbar/class/debugbarlogger.php
@@ -438,9 +438,9 @@ class DebugbarLogger implements LoggerInterface
     }
 
     /**
-     * dump everything we have
+     * dump everything we have  // was __destruct()
      */
-    public function __destruct()
+    public function renderDebugBar()
     {
         if ($this->activated) {
             // include any queued time data from Xmf\Debug

--- a/htdocs/modules/debugbar/preloads/preload.php
+++ b/htdocs/modules/debugbar/preloads/preload.php
@@ -341,13 +341,13 @@ class DebugbarPreload extends PreloadItem
     }
 
     /**
-     * eventCoreIncludeFunctionsRedirectheader
+     * eventCoreRedirectStart
      *
      * @param mixed $args arguments supplied to triggerEvent
      *
      * @return void
      */
-    public static function eventCoreIncludeFunctionsRedirectheaderStart($args)
+    public static function eventCoreRedirectStart($args)
     {
         DebugbarLogger::getInstance()->stackData();
     }
@@ -418,5 +418,17 @@ class DebugbarPreload extends PreloadItem
     public static function eventDebugTimerStop($args)
     {
         DebugbarLogger::getInstance()->stopTime($args);
+    }
+
+    /**
+     * eventCoreSessionShutdown
+     *
+     * @param mixed $args arguments supplied to triggerEvent
+     *
+     * @return void
+     */
+    public static function eventCoreSessionShutdown($args)
+    {
+        DebugbarLogger::getInstance()->renderDebugBar();
     }
 }

--- a/htdocs/modules/profile/preloads/core.php
+++ b/htdocs/modules/profile/preloads/core.php
@@ -42,8 +42,7 @@ class ProfileCorePreload extends XoopsPreloadItem
             $op = trim($_GET['op']);
         }
         if ($op != 'login' && (empty($_GET['from']) || 'profile' != $_GET['from'])) {
-            header("location: ./modules/profile/user.php" . (empty($_SERVER['QUERY_STRING']) ? "" : "?" . $_SERVER['QUERY_STRING']));
-            exit();
+            \Xoops::simpleRedirect("./modules/profile/user.php" . (empty($_SERVER['QUERY_STRING']) ? "" : "?" . $_SERVER['QUERY_STRING']));
         }
     }
 
@@ -54,8 +53,7 @@ class ProfileCorePreload extends XoopsPreloadItem
      */
     static public function eventCoreEdituserStart($args)
     {
-        header("location: ./modules/profile/edituser.php" . (empty($_SERVER['QUERY_STRING']) ? "" : "?" . $_SERVER['QUERY_STRING']));
-        exit();
+        \Xoops::simpleRedirect("./modules/profile/edituser.php" . (empty($_SERVER['QUERY_STRING']) ? "" : "?" . $_SERVER['QUERY_STRING']));
     }
 
     /**
@@ -67,8 +65,7 @@ class ProfileCorePreload extends XoopsPreloadItem
     {
         $email = isset($_GET['email']) ? trim($_GET['email']) : '';
         $email = isset($_POST['email']) ? trim($_POST['email']) : $email;
-        header("location: ./modules/profile/lostpass.php?email={$email}" . (empty($_GET['code']) ? "" : "&" . $_GET['code']));
-        exit();
+        \Xoops::simpleRedirect("./modules/profile/lostpass.php?email={$email}" . (empty($_GET['code']) ? "" : "&" . $_GET['code']));
     }
 
     /**
@@ -78,8 +75,7 @@ class ProfileCorePreload extends XoopsPreloadItem
      */
     static function eventCoreRegisterStart($args)
     {
-        header("location: ./modules/profile/register.php" . (empty($_SERVER['QUERY_STRING']) ? "" : "?" . $_SERVER['QUERY_STRING']) );
-        exit();
+        \Xoops::simpleRedirect("./modules/profile/register.php" . (empty($_SERVER['QUERY_STRING']) ? "" : "?" . $_SERVER['QUERY_STRING']) );
     }
 
     /**
@@ -89,8 +85,6 @@ class ProfileCorePreload extends XoopsPreloadItem
      */
     static function eventCoreUserinfoStart($args)
     {
-        header("location: ./modules/profile/userinfo.php" . (empty($_SERVER['QUERY_STRING']) ? "" : "?" . $_SERVER['QUERY_STRING']) );
-        exit();
+        \Xoops::simpleRedirect("./modules/profile/userinfo.php" . (empty($_SERVER['QUERY_STRING']) ? "" : "?" . $_SERVER['QUERY_STRING']) );
     }
-
 }

--- a/htdocs/xoops_lib/Xoops/Core/Events.php
+++ b/htdocs/xoops_lib/Xoops/Core/Events.php
@@ -32,7 +32,7 @@ class Events
     protected $preloadList = array();
 
     /**
-     * @var array $eventListeners - $eventListeners['eventname'][]=Closure
+     * @var array $eventListeners - $eventListeners['eventName'][]=Closure
      * key is event name, value is array of callables
      */
     protected $eventListeners = array();
@@ -59,7 +59,8 @@ class Events
         static $instance = false;
 
         if (!$instance) {
-            $instance = new \Xoops\Core\Events();
+            $instance = new Events();
+            $instance->initializeListeners();
         }
 
         return $instance;
@@ -68,14 +69,14 @@ class Events
     /**
      * initializePreloads - Initialize listeners with preload mapped events.
      *
-     * We supress event processing during establishing listener map. A a cache miss (on
+     * We suppress event processing during establishing listener map. A a cache miss (on
      * system_modules_active, for example) triggers regeneration, which may trigger events
      * that listeners are not prepared to handle. In such circumstances, module level class
      * mapping will not have been done.
      *
      * @return void
      */
-    public function initializeListeners()
+    protected function initializeListeners()
     {
         $this->eventsEnabled = false;
         // clear state in case this is invoked more than once
@@ -147,8 +148,10 @@ class Events
      */
     protected function setEvents()
     {
+        $xoops = \Xoops::getInstance();
         foreach ($this->preloadList as $preload) {
-            include_once \XoopsBaseConfig::get('root-path') . '/modules/' . $preload['module'] . '/preloads/' . $preload['file']. '.php';
+            $path = $xoops->path('modules/' . $preload['module'] . '/preloads/' . $preload['file']. '.php');
+            include_once $path;
             $class_name = ucfirst($preload['module'])
                 . ($preload['file'] == 'preload' ? '' : ucfirst($preload['file']) )
                 . 'Preload';
@@ -226,18 +229,9 @@ class Events
     }
 
     /**
-     * getPreloads - for debugging only, return list of preloads
-     *
-     * @return array of preloads
-     */
-    public function getPreloads()
-    {
-        return $this->preloadList;
-    }
-
-    /**
      * hasListeners - for debugging only, return list of event listeners
-     * @param type $eventName event name
+     *
+     * @param string $eventName event name
      *
      * @return boolean true if one or more listeners are registered for the event
      */

--- a/htdocs/xoops_lib/Xoops/Core/HttpRequest.php
+++ b/htdocs/xoops_lib/Xoops/Core/HttpRequest.php
@@ -19,22 +19,25 @@ namespace Xoops\Core;
  * should move to Xoops\Core\Request::getXyz() methods.
  *
  * These are methods which reveal some aspects of the HTTP request environment.
- * This will eventually be reworked to depend on a full HTTP messasge library
+ * This will eventually be reworked to depend on a full HTTP message library
  * (anticipating an official PSR-7 implementation.)
  *
  * For now, this is a reduced version of a Cake derivative.
  *
  */
 
-
-
 /**
- * @author          trabis <lusopoemas@gmail.com>
- * @author          Kazumi Ono <onokazu@gmail.com>
- * @copyright       XOOPS Project (http://xoops.org)
- * @license         GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * HttpRequest
+ *
+ * @category  Xoops\Core\HttpRequest
+ * @package   Xoops\Core
+ * @author    trabis <lusopoemas@gmail.com>
+ * @author    Kazumi Ono <onokazu@gmail.com>
+ * @author    Richard Griffith <richard@geekwright.com>
+ * @copyright 2011-2015 XOOPS Project (http://xoops.org)
+ * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      http://xoops.org
  */
-
 class HttpRequest
 {
     /**
@@ -166,6 +169,8 @@ class HttpRequest
     }
 
     /**
+     * get singleton instance, establish the request data on first access
+     *
      * @return HttpRequest
      */
     public static function getInstance()
@@ -179,6 +184,8 @@ class HttpRequest
     }
 
     /**
+     * get a http header for the current request
+     *
      * @param null|string $name header name
      *
      * @return null|string
@@ -206,6 +213,8 @@ class HttpRequest
     }
 
     /**
+     * get the scheme of current request
+     *
      * @return string
      */
     public function getScheme()
@@ -214,6 +223,8 @@ class HttpRequest
     }
 
     /**
+     * get the host from the current request
+     *
      * @return string
      */
     public function getHost()
@@ -222,6 +233,8 @@ class HttpRequest
     }
 
     /**
+     * get the URI of the current request
+     *
      * @return null|string
      */
     public static function getUri()
@@ -238,6 +251,8 @@ class HttpRequest
     }
 
     /**
+     * get the referer of the current request
+     *
      * @return string
      */
     public function getReferer()
@@ -246,6 +261,8 @@ class HttpRequest
     }
 
     /**
+     * get the current script name associated with the request
+     *
      * @return string
      */
     public function getScriptName()
@@ -285,6 +302,7 @@ class HttpRequest
      * to get a real routable address.
      *
      * @param boolean $considerProxy true to enable proxy tests
+     *
      * @return string
      */
     public function getClientIp($considerProxy = false)
@@ -343,8 +361,8 @@ class HttpRequest
      * environment information.
      * Note : code modifications for XOOPS
      *
-     * @param  string $name    Environment variable name.
-     * @param  mixed  $default default value
+     * @param string $name    Environment variable name.
+     * @param mixed  $default default value
      *
      * @return string|boolean Environment variable setting.
      * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#env
@@ -367,9 +385,9 @@ class HttpRequest
         }
 
         if ($name === 'REMOTE_ADDR' && !isset($_SERVER[$name])) {
-            $addr = $this->getEnv('HTTP_PC_REMOTE_ADDR');
-            if ($addr !== null) {
-                return $addr;
+            $address = $this->getEnv('HTTP_PC_REMOTE_ADDR');
+            if ($address !== null) {
+                return $address;
             }
         }
 
@@ -418,6 +436,8 @@ class HttpRequest
     }
 
     /**
+     * get files associated with the current request
+     *
      * @param string $name name of file
      *
      * @return array
@@ -529,7 +549,7 @@ class HttpRequest
      * ### Callback detectors
      * Callback detectors allow you to provide a 'callback' type to handle the check.  The callback will
      * receive the request object as its only parameter.
-     * e.g `addDetector('custom', array('callback' => array('SomeClass', 'somemethod')));`
+     * e.g `addDetector('custom', array('callback' => array('SomeClass', 'someMethod')));`
      * ### Request parameter detectors
      * Allows for custom detectors on the request parameters.
      * e.g `addDetector('post', array('param' => 'requested', 'value' => 1)`
@@ -543,7 +563,7 @@ class HttpRequest
     {
         $name = strtolower($name);
         if (isset($this->detectors[$name]) && isset($options['options'])) {
-            $options = Xoops_Utils::arrayRecursiveMerge($this->detectors[$name], $options);
+            $options = \Xoops_Utils::arrayRecursiveMerge($this->detectors[$name], $options);
         }
         $this->detectors[$name] = $options;
     }
@@ -563,7 +583,7 @@ class HttpRequest
         if (isset($accepts[$mediaType])) {
             return true;
         }
-        list($type, $subtype) = explode('/', $mediaType);
+        list($type) = explode('/', $mediaType);
         if (isset($accepts[$type.'/*'])) {
             return true;
         }
@@ -575,7 +595,7 @@ class HttpRequest
      * getAcceptMediaTypes returns the http-accept header as an
      * array of media types arranged by specified preference
      *
-     * @return array associtive array of preference (numeric weight >0 <=1.0 )
+     * @return array associative array of preference (numeric weight >0 <=1.0 )
      *               keyed by media types, and sorted by preference
      */
     public function getAcceptMediaTypes()
@@ -604,12 +624,12 @@ class HttpRequest
      * getAcceptedLanguages returns the http-accept-language header as an
      * array of language codes arranged by specified preference
      *
-     * @return array associtive array of preference (numeric weight >0 <=1.0 )
+     * @return array associative array of preference (numeric weight >0 <=1.0 )
      *               keyed by language code, and sorted by preference
      */
     public function getAcceptedLanguages()
     {
-        $langs = array();
+        $languages = array();
         $accept = $this->getHeader('ACCEPT_LANGUAGE');
 
         if (!empty($accept)) {
@@ -619,13 +639,13 @@ class HttpRequest
                 if (!isset($l[1])) {
                     $l[1] = 1.0;
                 }
-                $langs[trim($l[0])] = (float) $l[1];
+                $languages[trim($l[0])] = (float) $l[1];
             }
 
             // sort list based on value
-            arsort($langs, SORT_NUMERIC);
+            arsort($languages, SORT_NUMERIC);
         }
 
-        return($langs);
+        return($languages);
     }
 }

--- a/htdocs/xoops_lib/Xoops/Core/Session/Manager.php
+++ b/htdocs/xoops_lib/Xoops/Core/Session/Manager.php
@@ -96,7 +96,8 @@ class Manager implements AttributeInterface
         $sessionHandler = new Handler;
         session_set_save_handler($sessionHandler);
 
-        session_register_shutdown();
+        //session_register_shutdown();
+        register_shutdown_function(array($this, 'sessionShutdown'));
 
         session_start();
 
@@ -212,6 +213,15 @@ class Manager implements AttributeInterface
     public function user()
     {
         return $this->sessionUser;
+    }
+
+    /**
+     * shutdown function
+     */
+    public function sessionShutdown()
+    {
+        \Xoops::getInstance()->events()->triggerEvent('core.session.shutdown');
+        session_write_close();
     }
 
     // access session variables as attribute object

--- a/tests/unit/xoopsLib/Xoops/Core/EventsTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/EventsTest.php
@@ -24,8 +24,8 @@ class EventsTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-		$class = $this->myclass;
-		$this->object = $class::getInstance();
+        $class = $this->myclass;
+        $this->object = $class::getInstance();
     }
 
     /**
@@ -36,35 +36,31 @@ class EventsTest extends \PHPUnit_Framework_TestCase
     {
     }
 
-	public function test_getInstance()
-	{
-		$class = $this->myclass;
-		$instance = $class::getInstance();
-		$this->assertInstanceOf($class, $instance);
+    public function test_getInstance()
+    {
+        $class = $this->myclass;
+        $instance = $class::getInstance();
+        $this->assertInstanceOf($class, $instance);
 
-		$instance1 = $class::getInstance();
-		$this->assertSame($instance1, $instance);
-	}
+        $instance1 = $class::getInstance();
+        $this->assertSame($instance1, $instance);
+    }
 
-	public function test_initializeListeners()
-	{
+    public function test_initializeListeners()
+    {
         $instance = $this->object;
-
-        $instance->initializeListeners();
 
         $result = $instance->getEvents();
         $this->assertTrue(is_array($result));
-        $result = $instance->getPreloads();
-        $this->assertTrue(is_array($result));
-	}
+    }
 
     public function dummy_callback($arg)
     {
         $this->dummy_result = $arg;
     }
 
-	public function test_triggerEvent()
-	{
+    public function test_triggerEvent()
+    {
         $instance = $this->object;
 
         $callback = array($this,'dummy_callback');
@@ -73,28 +69,21 @@ class EventsTest extends \PHPUnit_Framework_TestCase
 
         $instance->triggerEvent('dummy.listener', array(1,2));
         $this->assertSame(array(1,2), $this->dummy_result);
-	}
+    }
 
-	public function test_getEvents()
-	{
+    public function test_getEvents()
+    {
         // see test_initializeListeners
-	}
+    }
 
-	public function test_getPreloads()
-	{
-        // see test_initializeListeners
-	}
-
-	public function test_hasListeners()
-	{
+    public function test_hasListeners()
+    {
         $instance = $this->object;
-
-        $instance->initializeListeners();
 
         $result = $instance->hasListeners('listener_doesnt_exist');
         $this->assertFalse($result);
 
         $result = $instance->hasListeners('core.header.checkcache');
         $this->assertTrue($result);
-	}
+    }
 }


### PR DESCRIPTION
### \Xoops
- PSR-2 cleanup
- add `\Xoops::simpleRedirect()`. This replaces simple redirects using PHP `header()` to change the location. This makes it possible to trigger an event prior to redirecting. Debugbar was modified to stack data on these events, so activity logged prior to the redirect is available.
- event `core.include.functions.redirectheader.start` changed to `core.redirect.start` which is triggered both by `\Xoops::redirect()` and `\Xoops::simpleRedirect()`.

### \Xoops\Core\Session\
- added locking transaction to write. This seems to have solved #370 (This was related to the, *now simple*, redirect done when the profile module is active, causing two writes to compete for the row.)
- added a **core.session.shutdown** event just before the session is written out and closed. This allows things like Debugbar to close everything out, so that the state can be saved in the session. Without this, for example, stacked data in Debugbar stayed around forever, as the session was saved before it was cleared when the debugbar was rendered. This allows this delicate balance to be controlled. (Down side, the final session write is not captured, although if needed, Monolog keeps going all the way to shutdown.)

### \Xoops\Core\Events
- visibility of initializeListeners() reduced to protected, and it now is invoked automatically in the constructor. It really should be a private concern of Events, and should not be invoked externally. With this method exposed, any program could compromise the integrity of the events system.

### \Xoops\Core\HttpRequest
- PSR-2 cleanup