### PR TITLE
Update phpunit version spec

### DIFF
--- a/htdocs/xoops_lib/composer.json
+++ b/htdocs/xoops_lib/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "raveren/kint": "*",
-        "phpunit/phpunit": "~4.1",
+        "phpunit/phpunit": ">=4.8",
         "phpunit/phpunit-skeleton-generator": "*"
     },
     "extra": {

--- a/htdocs/xoops_lib/composer.json.dist
+++ b/htdocs/xoops_lib/composer.json.dist
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "raveren/kint": "*",
-        "phpunit/phpunit": "~4.1",
+        "phpunit/phpunit": ">=4.8",
         "phpunit/phpunit-skeleton-generator": "*"
     },
     "extra": {


### PR DESCRIPTION
require-dev changed to a minimum of the 4.8 series, and also allows 5.0 for PHP 5.6+ systems.