### PR TITLE
Bug #426 (Smilies not visible)

### DIFF
--- a/htdocs/modules/avatars/templates/avatars_popup.tpl
+++ b/htdocs/modules/avatars/templates/avatars_popup.tpl
@@ -9,7 +9,7 @@ function myimage_onclick(counter)
 }
 function showAvatar()
 {
-    window.opener.xoopsGetElementById("avatar").src = '<{$smarty.const.XOOPS_UPLOAD_URL}>/' + window.opener.xoopsGetElementById("user_avatar").options[window.opener.xoopsGetElementById("user_avatar").selectedIndex].value;
+    window.opener.xoopsGetElementById("avatar").src = '<{$xoops_upload_url}>/' + window.opener.xoopsGetElementById("user_avatar").options[window.opener.xoopsGetElementById("user_avatar").selectedIndex].value;
 }
 //-->
 </script>

--- a/htdocs/modules/smilies/templates/admin/smilies_smilies.tpl
+++ b/htdocs/modules/smilies/templates/admin/smilies_smilies.tpl
@@ -27,7 +27,7 @@
             <tr class="<{cycle values='even,odd'}> alignmiddle">
                 <td class="txtcenter width10"><{$smiley.smiley_code}></td>
                 <td class="txtcenter width10">
-                    <img src="<{$smarty.const.XOOPS_UPLOAD_URL}>/<{$smiley.smiley_url}>" alt="<{$smile.emotion}>" />
+                    <img src="<{$xoops_upload_url}>/<{$smiley.smiley_url}>" alt="<{$smile.emotion}>" />
                 </td>
                 <td class="txtleft"><{$smiley.smiley_emotion}></td>
                 <td class="xo-actions txtcenter width5">

--- a/htdocs/modules/smilies/templates/smilies_tinymce.tpl
+++ b/htdocs/modules/smilies/templates/smilies_tinymce.tpl
@@ -20,7 +20,7 @@
     <div class="panel_wrapper">
         <div id="smilies_browser_panel" class="panel current" style="overflow:auto;">
             <{foreach from=$smileys item=smile}>
-                <img onmouseover="style.cursor='pointer'" onclick="Xoops_smiliesDialog.insert(this);" src="<{$smarty.const.XOOPS_UPLOAD_URL}>/<{$smile.smiley_url}>" alt="<{$smile.smiley_emotion}>" class="xoops_smilies" />
+                <img onmouseover="style.cursor='pointer'" onclick="Xoops_smiliesDialog.insert(this);" src="<{$xoops_upload_url}>/<{$smile.smiley_url}>" alt="<{$smile.smiley_emotion}>" class="xoops_smilies" />
             <{/foreach}>
             <div>
                 <a class="xoops_smilies" href="xoops_smilies.php?op=more" title="<{translate key='MORE'}>"><{translate key='MORE'}></a>


### PR DESCRIPTION
Somehow the: 
```php
<{$smarty.const.XOOPS_UPLOAD_URL}> 
```
didn't work.

After changing it to:
```php
<{$xoops_upload_url}> 
```
it works now.
