### PR TITLE
Round trip pizza delivery

### DIFF
--- a/console/Commands/CiBootstrapCommand.php
+++ b/console/Commands/CiBootstrapCommand.php
@@ -87,7 +87,7 @@ EOT;
             'smarty-compile' => $baseDir . '/xoops_data/caches/smarty_compile',
             'smarty-xoops-plugins' => $baseDir . '/xoops_lib/smarty/xoops_plugins',
             'db-type' => 'pdo_mysql',
-            'db-charset' => 'utf8',
+            'db-charset' => 'utf8mb4',
             'db-prefix' => 'x300',
             'db-host' => 'localhost',
             'db-user' => 'travis',
@@ -96,11 +96,12 @@ EOT;
             'db-pconnect' => 0,
             'db-parameters' => array(
                 'driver'   => 'pdo_mysql',
-                'charset'  => 'utf8',
+                'charset'  => 'utf8mb4',
                 'dbname'   => 'xoops_test',
                 'host'     => 'localhost',
                 'user'     => 'travis',
                 'password' => '',
+                'collate'  => 'utf8mb4_unicode_ci',
             ),
         );
         Yaml::saveWrapped($configs, $configFile);

--- a/console/Commands/Utf8mb4ModuleCommand.php
+++ b/console/Commands/Utf8mb4ModuleCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace XoopsConsole\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Doctrine\DBAL\Types\Type;
+
+
+class Utf8mb4ModuleCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setName("utf8mb4-module")
+            ->setDescription("Update a module's tables to utf8mb4")
+            ->setDefinition(array(
+                new InputArgument('module', InputArgument::REQUIRED, 'Module directory name'),
+            ))
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show but do not execute DDL.')
+            ->setHelp(<<<EOT
+The <info>utf8mb4-module</info> command updates the tables that are owned by an installed module
+to use MySQL's <info>utf8mb4</info> character set, and <info>utf8mb4_unicode_ci</info> collation.
+EOT
+             );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dirname = $input->getArgument('module');
+
+        $dryRun = false;
+        if ($input->getOption('dry-run')) {
+            $output->writeln('<info>dry-run option selected.</info>');
+            $dryRun = true;
+        }
+
+        $output->writeln(sprintf('Updating %s tables', $dirname));
+        $xoops = \Xoops::getInstance();
+        $module = $xoops->getModuleByDirname($dirname);
+        if (false === $module) {
+            $output->writeln(sprintf('<error>%s is not an installed module!</error>', $dirname));
+            return;
+        }
+        $module->loadInfo($dirname, false);
+        $modVersion = $module->modinfo;
+        $tableList =  isset($modVersion['tables']) ? $modVersion['tables'] : [];
+        //\Kint::dump($modVersion, $tableList);
+        $sql = [];
+
+        $manager = $xoops->db()->getSchemaManager();
+        $platform = $xoops->db()->getDatabasePlatform();
+
+        if ('mysql' !== $platform->getName()) {
+            $output->writeln('<error>This command only works on a MySQL platform.</error>');
+            return;
+        }
+
+        foreach ($tableList as $tableIn) {
+            $table = $xoops->db()->prefix($tableIn);
+
+            $sql[] = sprintf(
+                'ALTER TABLE %s CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;',
+                $platform->quoteIdentifier($table)
+            );
+            $columns = $manager->listTableColumns($table);
+            foreach ($columns as $column) {
+                $type = $column->getType()->getName();
+                if ($type === Type::STRING || $type === Type::TEXT) {
+                    //$column->setPlatformOption('collation', 'utf8mb4_unicode_ci');
+                    $sql[] = sprintf(
+                        'ALTER TABLE %s MODIFY %s %s COLLATE utf8mb4_unicode_ci;',
+                        $platform->quoteIdentifier($table),
+                        $platform->quoteIdentifier($column->getName()),
+                        $column->getType()->getSQLDeclaration($column->toArray(), $platform)
+                    );
+                }
+            }
+        }
+        foreach($sql as $alterSql) {
+            $output->writeln(sprintf('<info>Executing:</info> %s', $alterSql));
+            if (!$dryRun) {
+                $xoops->db()->setForce(true);
+                $result = $xoops->db()->query($alterSql);
+                if ($result === false) {
+                    $output->writeln(sprintf('<error>Execution failed: %d - %s</error>',
+                        $xoops->db()->errorCode(),
+                        implode(' - ',$xoops->db()->errorInfo())
+                    ));
+                    \Kint::dump($xoops->db()->errorInfo());
+                }
+            }
+        }
+    }
+}

--- a/console/console.php
+++ b/console/console.php
@@ -52,6 +52,7 @@ $app->addCommands(array(
     new \XoopsConsole\Commands\UpdateModuleCommand(),
     new \XoopsConsole\Commands\SetConfigCommand(),
     new \XoopsConsole\Commands\RenameSystemTablesCommand(),
+    new \XoopsConsole\Commands\Utf8mb4ModuleCommand(),
 ));
 
 $app->run();

--- a/htdocs/include/formdhtmltextarea.js
+++ b/htdocs/include/formdhtmltextarea.js
@@ -473,7 +473,7 @@ function form_checkserver(area_id)
 function form_instantPreview(xoopsUrl, area_id, imgurl, doHtml, token)
 {
     var imgUrl = xoopsUrl + '/images/form';
-    var data = escape(xoopsGetElementById(area_id).value);
+    var data = encodeURIComponent(xoopsGetElementById(area_id).value);
 
     var url_request = xoopsUrl + "/include/formdhtmltextarea_preview.php";//?text=" + data;
     var args =  "text=" + data;

--- a/htdocs/include/formdhtmltextarea_preview.php
+++ b/htdocs/include/formdhtmltextarea_preview.php
@@ -17,30 +17,30 @@
  * @author          Taiwen Jiang <phppp@users.sourceforge.net>
  * @version         $Id$
  */
-
+use Xoops\Core\Request;
 include_once dirname(__DIR__) . '/mainfile.php';
 
 $xoops = Xoops::getInstance();
-$xoops->disableErrorReporting();
+$xoops->logger()->quiet();
 $myts = MyTextSanitizer::getInstance();
 
-$content = $myts->stripSlashesGPC($_POST['text']);
+$content = Request::getString('text', '');
 
 if (!$xoops->security()->validateToken(@$_POST['token'], false)) {
     $content = 'Direct access is not allowed!!!';
 }
 $html = empty($_POST['html']) ? 0 : 1;
 $content = $myts->displayTarea($content, $html, 1, 1, 1, 1);
-if (preg_match_all('/%u([[:alnum:]]{4})/', $content, $matches)) {
-    foreach ($matches[1] as $uniord) {
-        $utf = '&#x' . $uniord . ';';
-        $content = str_replace('%u' . $uniord, $utf, $content);
-    }
-    $content = urldecode($content);
-}
+//if (preg_match_all('/%u([[:alnum:]]{4})/', $content, $matches)) {
+//    foreach ($matches[1] as $uniord) {
+//        $utf = '&#x' . $uniord . ';';
+//        $content = str_replace('%u' . $uniord, $utf, $content);
+//    }
+//    $content = urldecode($content);
+//}
 
 if (! headers_sent()) {
-    header('Content-Type:text/html; charset=ISO-8859-1');
+    header('Content-Type:text/html; charset=UTF-8');
     header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
     header('Cache-Control: private, no-cache');
     header('Pragma: no-cache');

--- a/htdocs/include/version.php
+++ b/htdocs/include/version.php
@@ -17,7 +17,7 @@
 
 /**
  * Define XOOPS version
- * @todo This should be eleminated in favor of \Xoops::VERSION, but it is still required in installer
+ * @todo This should be eliminated in favor of \Xoops::VERSION, but it is still required in installer
  */
-$XoopsIncludeVersionString  = class_exists('\Xoops', false) ? \Xoops::VERSION : 'UNKNOWN';
+$XoopsIncludeVersionString  = class_exists('\Xoops', false) ? \Xoops::VERSION : 'XOOPS 2.6.0';
 define('XOOPS_VERSION', $XoopsIncludeVersionString);

--- a/htdocs/install/include/config.php
+++ b/htdocs/install/include/config.php
@@ -164,6 +164,7 @@ $configs['writable'] = array(
 // Modules to be installed by default
 $configs['modules'] = array(
     'banners',
+    'notifications',
     'page',
     'search',
     'userconfigs',
@@ -178,11 +179,10 @@ $configs['ext'] = array(
     'mailusers',
     'maintenance',
     'menus',
-    'notifications',
     'protector',
     'smilies',
     'thumbs',
-    'xmf',
+//    'xmf',
 );
 
 // xoops_lib, xoops_data directories

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -483,6 +483,12 @@ function getDbConnectionParams()
         'charset' => 'utf8',
     );
 
+    // force mysql to use utf8mb4
+    if (false !== strstr($settings['DB_DRIVER'],'mysql')) {
+        $connectionParams['charset'] = 'utf8mb4';
+        $connectionParams['collate'] = 'utf8mb4_unicode_ci';
+    }
+
     foreach ($driver_params as $param) {
         if (!empty($settings[$wizard->configs['db_param_names'][$param]])) {
             $connectionParams[$param] = $settings[$wizard->configs['db_param_names'][$param]];

--- a/htdocs/install/locale/en_US/welcome.php
+++ b/htdocs/install/locale/en_US/welcome.php
@@ -20,7 +20,7 @@ $content = '
 <ul>
     <li>Web Server (<a href="http://www.apache.org/" rel="external">Apache</a>, IIS, etc)</li>
     <li><a href="http://www.php.net/" rel="external">PHP</a> 5.4 or higher </li>
-    <li><a href="http://www.mysql.com/" rel="external">MySQL</a> 5.1 or higher </li>
+    <li><a href="http://www.mysql.com/" rel="external">MySQL</a> 5.5.3 or higher </li>
 </ul>
 <h3>Before you install</h3>
 <ol>

--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -69,6 +69,13 @@ if (!$connection && !empty($settings['DB_NAME'])) {
                     $sql = $platform->getCreateDatabaseSQL($connection->quoteIdentifier($settings['DB_NAME']));
                     $result = $connection->exec($sql);
                     if ($result) {
+                        if ('mysql' === $platform->getName()) {
+                            $sql = sprintf(
+                                'ALTER DATABASE %s CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;',
+                                $connection->quoteIdentifier($settings['DB_NAME'])
+                            );
+                            $connection->exec($sql);
+                        }
                         // try to reconnect with the database specified
                         $connection = null;
                         $connection = getDbConnection($error);

--- a/htdocs/install/page_siteinit.php
+++ b/htdocs/install/page_siteinit.php
@@ -64,7 +64,7 @@ if (!$status) {
     $_SESSION['error'] = $system_module->error;
     //$sql = $xoops->db()->getConfiguration()->getSQLLogger()->queries;
 }
-
+$system_module->install('xmf');
 $pageHasForm = true;
 $pageHasHelp = false;
 

--- a/htdocs/modules/avatars/sql/schema.yml
+++ b/htdocs/modules/avatars/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     avatars_avatar:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             avatar_id:
                 name: avatar_id
@@ -118,7 +120,9 @@ tables:
                 unique: false
                 primary: false
     avatars_user_link:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             avatar_id:
                 name: avatar_id

--- a/htdocs/modules/banners/sql/schema.yml
+++ b/htdocs/modules/banners/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     banners_banner:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             banner_bid:
                 name: banner_bid
@@ -175,7 +177,9 @@ tables:
                 unique: false
                 primary: false
     banners_bannerclient:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             bannerclient_cid:
                 name: bannerclient_cid

--- a/htdocs/modules/comments/sql/schema.yml
+++ b/htdocs/modules/comments/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     comments:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             id:
                 name: id
@@ -124,7 +126,7 @@ tables:
                 type: string
                 default: ''
                 notnull: true
-                length: 15
+                length: 45
                 precision: 10
                 scale: 0
                 fixed: false

--- a/htdocs/modules/images/sql/schema.yml
+++ b/htdocs/modules/images/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     image:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             image_id:
                 name: image_id
@@ -123,7 +125,9 @@ tables:
                 unique: false
                 primary: false
     imagebody:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             image_id:
                 name: image_id
@@ -158,7 +162,9 @@ tables:
                 unique: false
                 primary: false
     imagecategory:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             imgcat_id:
                 name: imgcat_id

--- a/htdocs/modules/notifications/sql/schema.yml
+++ b/htdocs/modules/notifications/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     notifications:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             id:
                 name: id

--- a/htdocs/modules/notifications/xoops_version.php
+++ b/htdocs/modules/notifications/xoops_version.php
@@ -56,8 +56,8 @@ $modversion['onUninstall'] = 'include/install.php';
 $modversion['hasAdmin'] = 0;
 
 // Manage extension
-$modversion['extension']          = 1;
-$modversion['extension_module'][] = 'system';
+//$modversion['extension']          = 1;
+//$modversion['extension_module'][] = 'system';
 
 // table definitions
 $modversion['schema']           = 'sql/schema.yml';
@@ -71,7 +71,7 @@ $modversion['tables'] = array(
 /*
  Blocks
 */
-$modversion['blocks']   = array();
+$modversion['blocks'] = array();
 $modversion['blocks'][] = array(
     'file'        => 'notifications_blocks.php',
     'name'        => _MI_NOTIFICATIONS_BNAME1,

--- a/htdocs/modules/page/sql/schema.yml
+++ b/htdocs/modules/page/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     page_content:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             content_id:
                 name: content_id
@@ -28,7 +30,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_general_ci
+                collation: utf8mb4_unicode_ci
             content_shorttext:
                 name: content_shorttext
                 type: text
@@ -42,7 +44,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_general_ci
+                collation: utf8mb4_unicode_ci
             content_text:
                 name: content_text
                 type: text
@@ -56,7 +58,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_general_ci
+                collation: utf8mb4_unicode_ci
             content_create:
                 name: content_create
                 type: integer
@@ -161,7 +163,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_general_ci
+                collation: utf8mb4_unicode_ci
             content_mdescription:
                 name: content_mdescription
                 type: text
@@ -175,7 +177,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_general_ci
+                collation: utf8mb4_unicode_ci
             content_maindisplay:
                 name: content_maindisplay
                 type: boolean
@@ -408,7 +410,9 @@ tables:
                 unique: false
                 primary: false
     page_rating:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             rating_id:
                 name: rating_id
@@ -475,7 +479,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_general_ci
+                collation: utf8mb4_unicode_ci
             rating_date:
                 name: rating_date
                 type: integer
@@ -506,7 +510,9 @@ tables:
                 unique: false
                 primary: false
     page_related:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             related_id:
                 name: related_id
@@ -534,7 +540,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_general_ci
+                collation: utf8mb4_unicode_ci
             related_domenu:
                 name: related_domenu
                 type: boolean
@@ -573,7 +579,9 @@ tables:
                 unique: false
                 primary: false
     page_related_link:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             link_id:
                 name: link_id

--- a/htdocs/modules/profile/sql/schema.yml
+++ b/htdocs/modules/profile/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     profile_category:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             cat_id:
                 name: cat_id
@@ -61,7 +63,9 @@ tables:
                 unique: true
                 primary: true
     profile_field:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             field_id:
                 name: field_id
@@ -301,7 +305,9 @@ tables:
                 unique: false
                 primary: false
     profile_profile:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             profile_id:
                 name: profile_id
@@ -323,7 +329,9 @@ tables:
                 unique: true
                 primary: true
     profile_regstep:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             step_id:
                 name: step_id
@@ -402,7 +410,9 @@ tables:
                 unique: false
                 primary: false
     profile_visibility:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             field_id:
                 name: field_id

--- a/htdocs/modules/protector/sql/schema.yml
+++ b/htdocs/modules/protector/sql/schema.yml
@@ -1,11 +1,92 @@
 tables:
-    menus_menu:
+    protector_access:
         options:
             charset: utf8mb4
             collate: utf8mb4_unicode_ci
         columns:
-            id:
-                name: id
+            ip:
+                name: ip
+                type: string
+                default: 0.0.0.0
+                notnull: true
+                length: 255
+                precision: 10
+                scale: 0
+                fixed: false
+                unsigned: false
+                autoincrement: false
+                columnDefinition: null
+                comment: null
+                collation: utf8mb4_unicode_ci
+            request_uri:
+                name: request_uri
+                type: string
+                default: ''
+                notnull: true
+                length: 255
+                precision: 10
+                scale: 0
+                fixed: false
+                unsigned: false
+                autoincrement: false
+                columnDefinition: null
+                comment: null
+                collation: utf8mb4_unicode_ci
+            malicious_actions:
+                name: malicious_actions
+                type: string
+                default: ''
+                notnull: true
+                length: 255
+                precision: 10
+                scale: 0
+                fixed: false
+                unsigned: false
+                autoincrement: false
+                columnDefinition: null
+                comment: null
+                collation: utf8mb4_unicode_ci
+            expire:
+                name: expire
+                type: integer
+                default: '0'
+                notnull: true
+                length: null
+                precision: 10
+                scale: 0
+                fixed: false
+                unsigned: false
+                autoincrement: false
+                columnDefinition: null
+                comment: null
+        indexes:
+            ip:
+                name: ip
+                columns: [ip]
+                unique: false
+                primary: false
+            request_uri:
+                name: request_uri
+                columns: [request_uri]
+                unique: false
+                primary: false
+            malicious_actions:
+                name: malicious_actions
+                columns: [malicious_actions]
+                unique: false
+                primary: false
+            expire:
+                name: expire
+                columns: [expire]
+                unique: false
+                primary: false
+    protector_log:
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
+        columns:
+            lid:
+                name: lid
                 type: integer
                 default: null
                 notnull: true
@@ -17,8 +98,8 @@ tables:
                 autoincrement: true
                 columnDefinition: null
                 comment: null
-            pid:
-                name: pid
+            uid:
+                name: uid
                 type: integer
                 default: '0'
                 notnull: true
@@ -30,65 +111,11 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-            mid:
-                name: mid
-                type: integer
-                default: '0'
-                notnull: true
-                length: null
-                precision: 10
-                scale: 0
-                fixed: false
-                unsigned: true
-                autoincrement: false
-                columnDefinition: null
-                comment: null
-            title:
-                name: title
+            ip:
+                name: ip
                 type: string
-                default: ''
+                default: 0.0.0.0
                 notnull: true
-                length: 150
-                precision: 10
-                scale: 0
-                fixed: false
-                unsigned: false
-                autoincrement: false
-                columnDefinition: null
-                comment: null
-                collation: utf8mb4_unicode_ci
-            alt_title:
-                name: alt_title
-                type: string
-                default: ''
-                notnull: true
-                length: 150
-                precision: 10
-                scale: 0
-                fixed: false
-                unsigned: false
-                autoincrement: false
-                columnDefinition: null
-                comment: null
-                collation: utf8mb4_unicode_ci
-            visible:
-                name: visible
-                type: boolean
-                default: '0'
-                notnull: true
-                length: null
-                precision: 10
-                scale: 0
-                fixed: false
-                unsigned: true
-                autoincrement: false
-                columnDefinition: null
-                comment: null
-            link:
-                name: link
-                type: string
-                default: null
-                notnull: false
                 length: 255
                 precision: 10
                 scale: 0
@@ -98,25 +125,12 @@ tables:
                 columnDefinition: null
                 comment: null
                 collation: utf8mb4_unicode_ci
-            weight:
-                name: weight
-                type: boolean
-                default: '0'
-                notnull: true
-                length: null
-                precision: 10
-                scale: 0
-                fixed: false
-                unsigned: true
-                autoincrement: false
-                columnDefinition: null
-                comment: null
-            target:
-                name: target
+            type:
+                name: type
                 type: string
-                default: null
-                notnull: false
-                length: 10
+                default: ''
+                notnull: true
+                length: 255
                 precision: 10
                 scale: 0
                 fixed: false
@@ -125,8 +139,22 @@ tables:
                 columnDefinition: null
                 comment: null
                 collation: utf8mb4_unicode_ci
-            groups:
-                name: groups
+            agent:
+                name: agent
+                type: string
+                default: ''
+                notnull: true
+                length: 255
+                precision: 10
+                scale: 0
+                fixed: false
+                unsigned: false
+                autoincrement: false
+                columnDefinition: null
+                comment: null
+                collation: utf8mb4_unicode_ci
+            description:
+                name: description
                 type: text
                 default: null
                 notnull: false
@@ -139,8 +167,8 @@ tables:
                 columnDefinition: null
                 comment: null
                 collation: utf8mb4_unicode_ci
-            hooks:
-                name: hooks
+            extra:
+                name: extra
                 type: text
                 default: null
                 notnull: false
@@ -153,75 +181,42 @@ tables:
                 columnDefinition: null
                 comment: null
                 collation: utf8mb4_unicode_ci
-            image:
-                name: image
-                type: string
+            timestamp:
+                name: timestamp
+                type: datetime
                 default: null
                 notnull: false
-                length: 255
-                precision: 10
-                scale: 0
-                fixed: false
-                unsigned: false
-                autoincrement: false
-                columnDefinition: null
-                comment: null
-                collation: utf8mb4_unicode_ci
-            css:
-                name: css
-                type: string
-                default: null
-                notnull: false
-                length: 255
-                precision: 10
-                scale: 0
-                fixed: false
-                unsigned: false
-                autoincrement: false
-                columnDefinition: null
-                comment: null
-                collation: utf8mb4_unicode_ci
-        indexes:
-            PRIMARY:
-                name: PRIMARY
-                columns: [id]
-                unique: true
-                primary: true
-    menus_menus:
-        options:
-            charset: utf8mb4
-            collate: utf8mb4_unicode_ci
-        columns:
-            id:
-                name: id
-                type: integer
-                default: null
-                notnull: true
                 length: null
                 precision: 10
                 scale: 0
                 fixed: false
-                unsigned: true
-                autoincrement: true
-                columnDefinition: null
-                comment: null
-            title:
-                name: title
-                type: string
-                default: ''
-                notnull: true
-                length: 150
-                precision: 10
-                scale: 0
-                fixed: false
                 unsigned: false
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8mb4_unicode_ci
         indexes:
             PRIMARY:
                 name: PRIMARY
-                columns: [id]
+                columns: [lid]
                 unique: true
                 primary: true
+            uid:
+                name: uid
+                columns: [uid]
+                unique: false
+                primary: false
+            ip:
+                name: ip
+                columns: [ip]
+                unique: false
+                primary: false
+            type:
+                name: type
+                columns: [type]
+                unique: false
+                primary: false
+            timestamp:
+                name: timestamp
+                columns: [timestamp]
+                unique: false
+                primary: false

--- a/htdocs/modules/protector/xoops_version.php
+++ b/htdocs/modules/protector/xoops_version.php
@@ -61,9 +61,12 @@ $modversion['extension_module'][] = 'system';
 /*
  Mysql and tables
  */
-$modversion['sqlfile']['mysql'] = "sql/mysql.sql";
-$modversion['tables'][0] = "protector_log";
-$modversion['tables'][1] = "protector_access";
+$modversion['schema']           = 'sql/schema.yml';
+$modversion['sqlfile']['mysql'] = 'sql/mysql.sql';
+$modversion['tables'] = array(
+    'protector_log',
+    'protector_access',
+);
 
 /*
  Admin things
@@ -73,9 +76,11 @@ $modversion['adminindex'] = "admin/index.php";
 $modversion['adminmenu'] = "admin/menu.php";
 
 // Admin Templates
-$modversion['templates'][] = array( 'file' => 'protector_advisory.html', 'description' => '', 'type' => 'admin' );
-$modversion['templates'][] = array( 'file' => 'protector_prefix.html', 'description' => '', 'type' => 'admin' );
-$modversion['templates'][] = array( 'file' => 'protector_center.html', 'description' => '', 'type' => 'admin' );
+$modversion['templates'] = array(
+    array( 'file' => 'protector_advisory.html', 'description' => '', 'type' => 'admin' ),
+    array( 'file' => 'protector_prefix.html', 'description' => '', 'type' => 'admin' ),
+    array( 'file' => 'protector_center.html', 'description' => '', 'type' => 'admin' ),
+);
 
 /*
  Blocks

--- a/htdocs/modules/publisher/sql/schema.yml
+++ b/htdocs/modules/publisher/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     publisher_categories:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             categoryid:
                 name: categoryid
@@ -41,7 +43,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             description:
                 name: description
                 type: text
@@ -55,7 +57,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             image:
                 name: image
                 type: string
@@ -69,7 +71,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             total:
                 name: total
                 type: integer
@@ -122,7 +124,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             header:
                 name: header
                 type: text
@@ -136,7 +138,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             meta_keywords:
                 name: meta_keywords
                 type: text
@@ -150,7 +152,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             meta_description:
                 name: meta_description
                 type: text
@@ -164,7 +166,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             short_url:
                 name: short_url
                 type: string
@@ -178,7 +180,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             moderator:
                 name: moderator
                 type: integer
@@ -204,7 +206,9 @@ tables:
                 unique: false
                 primary: false
     publisher_files:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             fileid:
                 name: fileid
@@ -245,7 +249,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             description:
                 name: description
                 type: text
@@ -259,7 +263,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             filename:
                 name: filename
                 type: string
@@ -273,7 +277,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             mimetype:
                 name: mimetype
                 type: string
@@ -287,7 +291,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             uid:
                 name: uid
                 type: integer
@@ -360,7 +364,9 @@ tables:
                 unique: true
                 primary: true
     publisher_items:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             itemid:
                 name: itemid
@@ -401,7 +407,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             subtitle:
                 name: subtitle
                 type: string
@@ -415,7 +421,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             summary:
                 name: summary
                 type: text
@@ -429,7 +435,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             body:
                 name: body
                 type: text
@@ -443,7 +449,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             uid:
                 name: uid
                 type: integer
@@ -470,7 +476,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             datesub:
                 name: datesub
                 type: integer
@@ -523,7 +529,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             counter:
                 name: counter
                 type: integer
@@ -693,7 +699,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             meta_description:
                 name: meta_description
                 type: text
@@ -707,7 +713,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             short_url:
                 name: short_url
                 type: string
@@ -721,7 +727,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             item_tag:
                 name: item_tag
                 type: text
@@ -735,7 +741,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
         indexes:
             PRIMARY:
                 name: PRIMARY
@@ -753,7 +759,9 @@ tables:
                 unique: false
                 primary: false
     publisher_meta:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             metakey:
                 name: metakey
@@ -768,7 +776,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             metavalue:
                 name: metavalue
                 type: string
@@ -782,7 +790,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
         indexes:
             PRIMARY:
                 name: PRIMARY
@@ -790,7 +798,9 @@ tables:
                 unique: true
                 primary: true
     publisher_mimetypes:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             mime_id:
                 name: mime_id
@@ -818,7 +828,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             mime_types:
                 name: mime_types
                 type: text
@@ -832,7 +842,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             mime_name:
                 name: mime_name
                 type: string
@@ -846,7 +856,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             mime_admin:
                 name: mime_admin
                 type: integer
@@ -880,7 +890,9 @@ tables:
                 unique: true
                 primary: true
     publisher_rating:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             ratingid:
                 name: ratingid
@@ -960,7 +972,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
         indexes:
             PRIMARY:
                 name: PRIMARY

--- a/htdocs/modules/schematool/admin/schematool.php
+++ b/htdocs/modules/schematool/admin/schematool.php
@@ -85,8 +85,21 @@ if ($op == 'showschema') {
         $export = new ExportVisitor;
         $newSchema->visit($export);
 
+        $schemaArray = $export->getSchemaArray();
+
+        // enforce utf8mb4 for MySQL
+        foreach ($schemaArray['tables'] as $tableName => $table) {
+            $schemaArray['tables'][$tableName]['options']['charset'] = 'utf8mb4';
+            $schemaArray['tables'][$tableName]['options']['collate'] = 'utf8mb4_unicode_ci';
+            foreach ($table['columns'] as $column => $data) {
+                if (array_key_exists('collation', $data)) {
+                    $schemaArray['tables'][$tableName]['columns'][$column]['collation'] = 'utf8mb4_unicode_ci';
+                }
+            }
+        }
+
         echo '<h2>' . _MI_SCHEMATOOL_EXPORT_SCHEMA . '</h2>';
-        $yamldump = Yaml::dump($export->getSchemaArray(), 5);
+        $yamldump = Yaml::dump($schemaArray, 5);
         //echo '<div contenteditable><pre>' . $yamldump . '</pre></div>';
         $schemadump = <<<EOT1
 <section>

--- a/htdocs/modules/smilies/sql/schema.yml
+++ b/htdocs/modules/smilies/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     smilies:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             smiley_id:
                 name: smiley_id

--- a/htdocs/modules/system/sql/schema.yml
+++ b/htdocs/modules/system/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     system_block:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             bid:
                 name: bid
@@ -54,7 +56,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             name:
                 name: name
                 type: string
@@ -68,7 +70,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             title:
                 name: title
                 type: string
@@ -82,7 +84,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             content:
                 name: content
                 type: text
@@ -96,7 +98,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             side:
                 name: side
                 type: smallint
@@ -149,7 +151,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             c_type:
                 name: c_type
                 type: string
@@ -163,7 +165,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             isactive:
                 name: isactive
                 type: boolean
@@ -190,7 +192,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             func_file:
                 name: func_file
                 type: string
@@ -204,7 +206,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             show_func:
                 name: show_func
                 type: string
@@ -218,7 +220,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             edit_func:
                 name: edit_func
                 type: string
@@ -232,7 +234,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             template:
                 name: template
                 type: string
@@ -246,7 +248,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             bcachetime:
                 name: bcachetime
                 type: integer
@@ -300,7 +302,9 @@ tables:
                 unique: false
                 primary: false
     system_blockmodule:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             module_id:
                 name: module_id
@@ -335,7 +339,9 @@ tables:
                 unique: true
                 primary: true
     system_config:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             conf_id:
                 name: conf_id
@@ -389,7 +395,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             conf_title:
                 name: conf_title
                 type: string
@@ -403,7 +409,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             conf_value:
                 name: conf_value
                 type: text
@@ -417,7 +423,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             conf_desc:
                 name: conf_desc
                 type: string
@@ -431,7 +437,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             conf_formtype:
                 name: conf_formtype
                 type: string
@@ -445,7 +451,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             conf_valuetype:
                 name: conf_valuetype
                 type: string
@@ -459,7 +465,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             conf_order:
                 name: conf_order
                 type: smallint
@@ -490,7 +496,9 @@ tables:
                 unique: false
                 primary: false
     system_configoption:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             confop_id:
                 name: confop_id
@@ -518,7 +526,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             confop_value:
                 name: confop_value
                 type: string
@@ -532,7 +540,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             conf_id:
                 name: conf_id
                 type: smallint
@@ -558,7 +566,9 @@ tables:
                 unique: false
                 primary: false
     system_group:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             groupid:
                 name: groupid
@@ -586,7 +596,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             description:
                 name: description
                 type: text
@@ -600,7 +610,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             group_type:
                 name: group_type
                 type: string
@@ -614,7 +624,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
         indexes:
             PRIMARY:
                 name: PRIMARY
@@ -627,7 +637,9 @@ tables:
                 unique: false
                 primary: false
     system_module:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             mid:
                 name: mid
@@ -655,7 +667,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             version:
                 name: version
                 type: smallint
@@ -721,7 +733,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             hasmain:
                 name: hasmain
                 type: boolean
@@ -852,7 +864,9 @@ tables:
                 unique: false
                 primary: false
     system_online:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             online_uid:
                 name: online_uid
@@ -880,7 +894,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             online_updated:
                 name: online_updated
                 type: integer
@@ -912,7 +926,7 @@ tables:
                 type: string
                 default: ''
                 notnull: true
-                length: 15
+                length: 45
                 precision: 10
                 scale: 0
                 fixed: false
@@ -920,7 +934,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
         indexes:
             online_module:
                 name: online_module
@@ -938,7 +952,9 @@ tables:
                 unique: false
                 primary: false
     system_permission:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             gperm_id:
                 name: gperm_id
@@ -1005,7 +1021,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
         indexes:
             PRIMARY:
                 name: PRIMARY
@@ -1028,7 +1044,9 @@ tables:
                 unique: false
                 primary: false
     system_privatemessage:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             msg_id:
                 name: msg_id
@@ -1056,7 +1074,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             subject:
                 name: subject
                 type: string
@@ -1070,7 +1088,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             from_userid:
                 name: from_userid
                 type: integer
@@ -1123,7 +1141,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             read_msg:
                 name: read_msg
                 type: boolean
@@ -1216,7 +1234,9 @@ tables:
                 unique: false
                 primary: false
     system_session:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             session_id:
                 name: session_id
@@ -1231,7 +1251,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             expires_at:
                 name: expires_at
                 type: integer
@@ -1258,7 +1278,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
         indexes:
             PRIMARY:
                 name: PRIMARY
@@ -1271,7 +1291,9 @@ tables:
                 unique: false
                 primary: false
     system_tplfile:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             tpl_id:
                 name: tpl_id
@@ -1312,7 +1334,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             tpl_tplset:
                 name: tpl_tplset
                 type: string
@@ -1326,7 +1348,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             tpl_file:
                 name: tpl_file
                 type: string
@@ -1340,7 +1362,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             tpl_desc:
                 name: tpl_desc
                 type: string
@@ -1354,7 +1376,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             tpl_lastmodified:
                 name: tpl_lastmodified
                 type: integer
@@ -1394,7 +1416,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
         indexes:
             PRIMARY:
                 name: PRIMARY
@@ -1412,7 +1434,9 @@ tables:
                 unique: false
                 primary: false
     system_tplset:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             tplset_id:
                 name: tplset_id
@@ -1440,7 +1464,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             tplset_desc:
                 name: tplset_desc
                 type: string
@@ -1454,7 +1478,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             tplset_credits:
                 name: tplset_credits
                 type: text
@@ -1468,7 +1492,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             tplset_created:
                 name: tplset_created
                 type: integer
@@ -1489,7 +1513,9 @@ tables:
                 unique: true
                 primary: true
     system_tplsource:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             tpl_id:
                 name: tpl_id
@@ -1517,7 +1543,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
         indexes:
             tplsource_tpl_id:
                 name: tplsource_tpl_id
@@ -1525,7 +1551,9 @@ tables:
                 unique: false
                 primary: false
     system_user:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             uid:
                 name: uid
@@ -1553,7 +1581,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             uname:
                 name: uname
                 type: string
@@ -1567,7 +1595,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             email:
                 name: email
                 type: string
@@ -1581,7 +1609,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             url:
                 name: url
                 type: string
@@ -1595,7 +1623,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             user_avatar:
                 name: user_avatar
                 type: string
@@ -1609,7 +1637,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             user_regdate:
                 name: user_regdate
                 type: integer
@@ -1636,7 +1664,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             user_from:
                 name: user_from
                 type: string
@@ -1650,7 +1678,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             user_sig:
                 name: user_sig
                 type: text
@@ -1664,7 +1692,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             user_viewemail:
                 name: user_viewemail
                 type: boolean
@@ -1691,7 +1719,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             user_aim:
                 name: user_aim
                 type: string
@@ -1705,7 +1733,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             user_yim:
                 name: user_yim
                 type: string
@@ -1719,7 +1747,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             user_msnm:
                 name: user_msnm
                 type: string
@@ -1733,7 +1761,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             pass:
                 name: pass
                 type: string
@@ -1747,7 +1775,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             posts:
                 name: posts
                 type: integer
@@ -1813,7 +1841,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             timezone_offset:
                 name: timezone_offset
                 type: float
@@ -1840,6 +1868,19 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
+            last_pass_change:
+                name: last_pass_change
+                type: integer
+                default: '0'
+                notnull: true
+                length: null
+                precision: 10
+                scale: 0
+                fixed: false
+                unsigned: true
+                autoincrement: false
+                columnDefinition: null
+                comment: ''
             umode:
                 name: umode
                 type: string
@@ -1853,7 +1894,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             uorder:
                 name: uorder
                 type: smallint
@@ -1906,7 +1947,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             bio:
                 name: bio
                 type: text
@@ -1920,7 +1961,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             user_intrest:
                 name: user_intrest
                 type: string
@@ -1934,7 +1975,7 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
-                collation: utf8_unicode_ci
+                collation: utf8mb4_unicode_ci
             user_mailok:
                 name: user_mailok
                 type: boolean
@@ -1980,7 +2021,9 @@ tables:
                 unique: false
                 primary: false
     system_usergroup:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             linkid:
                 name: linkid

--- a/htdocs/modules/userconfigs/sql/schema.yml
+++ b/htdocs/modules/userconfigs/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     userconfigs_item:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             conf_id:
                 name: conf_id
@@ -149,7 +151,9 @@ tables:
                 unique: false
                 primary: false
     userconfigs_option:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             confop_id:
                 name: confop_id

--- a/htdocs/modules/userrank/sql/schema.yml
+++ b/htdocs/modules/userrank/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     userrank_rank:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             rank_id:
                 name: rank_id

--- a/htdocs/modules/xlanguage/sql/schema.yml
+++ b/htdocs/modules/xlanguage/sql/schema.yml
@@ -1,6 +1,8 @@
 tables:
     xlanguage:
-        options: {  }
+        options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         columns:
             xlanguage_id:
                 name: xlanguage_id

--- a/htdocs/xoops_lib/Xoops/Core/Kernel/Handlers/XoopsPrivateMessageHandler.php
+++ b/htdocs/xoops_lib/Xoops/Core/Kernel/Handlers/XoopsPrivateMessageHandler.php
@@ -63,9 +63,9 @@ class XoopsPrivateMessageHandler extends XoopsPersistableObjectHandler
     public function setRead(XoopsPrivateMessage $pm)
     {
         $qb = $this->db2->createXoopsQueryBuilder()
-            ->update($this->table, 'pm')
-            ->set('pm.read_msg', ':readmsg')
-            ->where('pm.msg_id = :msgid')
+            ->update($this->table)
+            ->set('read_msg', ':readmsg')
+            ->where('msg_id = :msgid')
             ->setParameter(':readmsg', 1, \PDO::PARAM_INT)
             ->setParameter(':msgid', (int)$pm->getVar('msg_id'), \PDO::PARAM_INT);
         $result = $qb->execute();


### PR DESCRIPTION
Some changes to implement MySQL utf8mb4 support.

The browser speaks UTF-8, XOOPS speaks UTF-8, but MySQL only gets it part way, speaking only BMP, or plane 0, the Basic Multilingual Plane. This leaves out some CJK support, among other things.

This change forces full Unicode UTF-8 support, using MySQL's *utf8mb4* character set and *utf8mb4_unicode_ci* collation. **Note: this raises the minimum MySQL version to 5.5.3**. As this was released in 2010, most deployments are at or well above this level.

Without this, valid UTF-8 characters could be entered, but would create errors when stored to the database. One practical example is entering emoji (such as the pizza slice) on a mobile device. The
emoji codes are in plane 1, the Supplementary Multilingual Plane.

With this change, emoji can make a round trip from browser, though XOOPS to the database, and back again. The platform specific directives are ignored if something other than MySQL is used, such
as SqLite (which already supports full UTF-8.)

New installs will get the full treatment, while existing tables need to be converted manually, or with the new console command, *utf8mb4-module* which updates all tables associated with a module.
i.e. `php console.php utf8mb4-module system`

The *schematool* module now adds the appropriate charset and collate options. Various other issues that were noted during development and testing were patched, too.
