### PR TITLE
Minor fix to abstract getDhtmlEditorSupport()

### DIFF
--- a/htdocs/xoops_lib/Xoops/Core/Text/Sanitizer/ExtensionAbstract.php
+++ b/htdocs/xoops_lib/Xoops/Core/Text/Sanitizer/ExtensionAbstract.php
@@ -48,7 +48,7 @@ abstract class ExtensionAbstract extends SanitizerComponent
      */
     public function getDhtmlEditorSupport($textAreaId)
     {
-        return array();
+        return array('', '');
     }
 
     /**

--- a/htdocs/xoops_lib/Xoops/Core/Text/Sanitizer/Extensions/XoopsCode.php
+++ b/htdocs/xoops_lib/Xoops/Core/Text/Sanitizer/Extensions/XoopsCode.php
@@ -32,19 +32,6 @@ class XoopsCode extends ExtensionAbstract
     protected static $defaultConfiguration = ['enabled' => true];
 
     /**
-     * This is provided in Xoops\Form\DhtmlTextArea
-     * Provide button and javascript code used by the DhtmlTextArea
-     *
-     * @param string $textAreaId dom element id
-     *
-     * @return string[] editor button as HTML, supporting javascript
-     */
-    public function getDhtmlEditorSupport($textAreaId)
-    {
-        return [];
-    }
-
-    /**
      * Register extension with the supplied sanitizer instance
      *
      * @return void


### PR DESCRIPTION
Should return array of two strings, not empty array.