### PR TITLE
Shortcode processing in theme

### DIFF
--- a/htdocs/modules/search/templates/search.tpl
+++ b/htdocs/modules/search/templates/search.tpl
@@ -1,5 +1,6 @@
 <fieldset>
     <{if $search|default:false}>
+    <{noshortcodes}>
         <legend><{$smarty.const._MD_SEARCH_SEARCHRESULTS}></legend>
         <div>
             <{$smarty.const._MD_SEARCH_KEYWORDS}>&nbsp;:&nbsp;
@@ -23,6 +24,7 @@
                 </span>
             </div>
         <{/if}>
+    <{/noshortcodes}>
     <{/if}>
 
     <{if count($modules) > 0}>

--- a/htdocs/xoops_data/configs/system_configs.php
+++ b/htdocs/xoops_data/configs/system_configs.php
@@ -28,6 +28,9 @@ return array(
         // iframe clickjack protection - value used to set X-Frame-Options header
         //'xFrameOptions' => 'sameorigin',
 
+        // set to true to disable shortcode processing in theme
+        //'disable_theme_shortcodes' => true,
+
         /** XOOPS admin security warnings
          *
          * <ul>Display admin security warnings:
@@ -35,5 +38,5 @@ return array(
          *  <li> 1 - Enabled</li>
          * </ul>
          */
-        "admin_warnings_enable" => 1,
+        'admin_warnings_enable' => 1,
     );

--- a/htdocs/xoops_lib/Xoops/Core/Text/Sanitizer.php
+++ b/htdocs/xoops_lib/Xoops/Core/Text/Sanitizer.php
@@ -202,6 +202,19 @@ class Sanitizer extends SanitizerConfigurable
     }
 
     /**
+     * Escape any brackets ([]) to make them invisible to ShortCodes
+     *
+     * @param string $text string to escape
+     *
+     * @return string
+     */
+    public function escapeShortCodes($text)
+    {
+        $text = str_replace(['[', ']'], ['&#91;', '&#93;'], $text);
+        return $text;
+    }
+
+    /**
      * Reverses htmlSpecialChars()
      *
      * @param string $text htmlSpecialChars encoded text

--- a/htdocs/xoops_lib/Xoops/Core/Text/ShortCodes.php
+++ b/htdocs/xoops_lib/Xoops/Core/Text/ShortCodes.php
@@ -173,7 +173,8 @@ class ShortCodes
     {
         // allow [[foo]] syntax for escaping a tag
         if ($tag[1] === '[' && $tag[6] === ']') {
-            return substr($tag[0], 1, -1);
+            //return substr($tag[0], 1, -1);
+            return '&#91;' . substr($tag[0], 2, -2) . '&#93';
         }
 
         $tagName = $tag[2];

--- a/htdocs/xoops_lib/Xoops/Core/Theme/XoopsTheme.php
+++ b/htdocs/xoops_lib/Xoops/Core/Theme/XoopsTheme.php
@@ -457,6 +457,7 @@ class XoopsTheme
 
         // Do not cache the main (theme.html) template output
         $this->template->caching = 0;
+        $this->template->loadFilter('output', 'shortcodes');
         $this->template->display($this->path . '/' . $this->canvasTemplate);
         $this->renderCount++;
         $xoops->events()->triggerEvent('core.theme.render.end', array($this));

--- a/htdocs/xoops_lib/Xoops/Core/Theme/XoopsTheme.php
+++ b/htdocs/xoops_lib/Xoops/Core/Theme/XoopsTheme.php
@@ -457,7 +457,9 @@ class XoopsTheme
 
         // Do not cache the main (theme.html) template output
         $this->template->caching = 0;
-        $this->template->loadFilter('output', 'shortcodes');
+        if (false === (bool)($xoops->getConfig('disable_theme_shortcodes'))) {
+            $this->template->loadFilter('output', 'shortcodes');
+        }
         $this->template->display($this->path . '/' . $this->canvasTemplate);
         $this->renderCount++;
         $xoops->events()->triggerEvent('core.theme.render.end', array($this));

--- a/htdocs/xoops_lib/smarty/xoops_plugins/block.noshortcodes.php
+++ b/htdocs/xoops_lib/smarty/xoops_plugins/block.noshortcodes.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * Smarty plugin
+ * ------------------------------------------------------------
+ * Type:       block
+ * Name:       noshortcode
+ * Purpose:    XOOPS smarty plugin to disable theme level ShortCode processing for a section of a template.
+ *             ShortCodes are surrounded by square brackets ([]). The outputfilter.shortcodes.php
+ *             plugin is called to process shortcodes anywhere in the entire output, however, there
+ *             are times when it might be desired to disable that processing for a section of a
+ *             template. This is accomplished by converting any brackets ([]) to visually equivalent
+ *             HTML entities (&#91;&#93;) so they will be ignored by the outputfilter.
+ * Author:     Richard Griffith <richard@geekwright.com>
+ * Version:    1.0
+ *
+ * Parameters: none
+ *
+ * Example:
+ * <{noshortcodes}>[skip]<{/noshortcodes}>
+ *
+ * Example output:
+ * &#91;skip&#93;
+ * ------------------------------------------------------------
+ */
+
+function smarty_block_noshortcodes($params, $content, $template, &$repeat)
+{
+    // only output on the closing tag
+    if(!$repeat){
+        if (isset($content)) {
+            $ts = \Xoops\Core\Text\Sanitizer::getInstance();
+            return $ts->escapeShortCodes($content);
+        }
+    }
+}

--- a/htdocs/xoops_lib/smarty/xoops_plugins/outputfilter.shortcodes.php
+++ b/htdocs/xoops_lib/smarty/xoops_plugins/outputfilter.shortcodes.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Smarty plugin to enable shortcodes in templates
+ */
+function smarty_outputfilter_shortcodes($output, Smarty_Internal_Template $template)
+{
+    $shortcodes = \Xoops\Core\Text\Sanitizer::getInstance()->getShortCodes();
+
+    // break out the body content
+    $bodyPattern = '/(([\S\s]*)((?><body[\S\s]*>)))([\S\s]*)((?><\/body>)([\S\s]*)$)/U';
+
+    // breaks out sections of string which are not part of form elements
+    $scPattern = '/(([\S\s]*)((?><textarea[\S\s]*\/textarea>)+|(?><input[\S\s]*>)+|(?><select[\S\s]*\/select>)+|(?><script[\S\s]*\/script>+)|(?><style[\S\s]*\/style>)+))/U';
+
+    $text = preg_replace_callback(
+        $bodyPattern,
+        function ($matches) use ($scPattern, $shortcodes) {
+            $body = preg_replace_callback(
+                $scPattern,
+                function ($innerMatches) use ($shortcodes) {
+                    $text = $shortcodes->process($innerMatches[2]) . $innerMatches[3];
+                    return $text;
+                },
+                $matches[4] . '<input>'
+            );
+            return $matches[1] . substr($body, 0, -7) . $matches[5];
+        },
+        $output
+    );
+
+    return $text;
+}

--- a/tests/unit/xoopsLib/Xoops/Core/Text/SanitizerTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/Text/SanitizerTest.php
@@ -155,6 +155,17 @@ class SanitizerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Xoops\Core\Text\Sanitizer::escapeShortCodes
+     */
+    public function testEscapeShortCodes()
+    {
+        $text = '[Random] [brackets]][';
+        $expected = '&#91;Random&#93; &#91;brackets&#93;&#93;&#91;';
+        $actual = $this->object->escapeShortCodes($text);
+        $this->assertEquals($actual, $expected);
+    }
+
+    /**
      * @covers Xoops\Core\Text\Sanitizer::undoHtmlSpecialChars
      */
     public function testUndoHtmlSpecialChars()

--- a/tests/unit/xoopsLib/Xoops/Core/Text/ShortCodesTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/Text/ShortCodesTest.php
@@ -290,7 +290,8 @@ class ShortCodesTest extends \PHPUnit_Framework_TestCase
         $shortcodes = new Shortcodes;
         $shortcodes->addShortcode('test', array($this, 'dummyFunction_test'));
         $content = 'Hello my name is [[test name="Sam"]]!';
-        $expectation = 'Hello my name is [test name="Sam"]!';
+        //$expectation = 'Hello my name is [test name="Sam"]!';
+        $expectation = 'Hello my name is &#91;test name="Sam"&#93!';
 
         $this->assertEquals($expectation, $shortcodes->process($content));
     }


### PR DESCRIPTION
Enable processing shortcodes through a Smarty filter as the theme is rendered. This allows shortcodes to be used anywhere, in templates or other output.

There are circumstances where this processing may not be appropriate.

Shortcodes inside form elements are not processed.

To suppress the processing in other areas in a template,  there is now a Smarty {noshortcodes} plugin. ShortCodes in between `{noshortcodes}` and  `{/noshortcodes}` tags will not be processed. An example is the search module, where the user entered search terms are echoed back.

Also, there is a new `Xoops\Core\Text\Sanitizer:: escapeShortCodes()` method that will disable any shortcodes in a string.

Setting the *disable_theme_shortcodes* system config to *true* will disable all shortcode processing at the theme level.

With this new capability and  associated controls, shortcodes add a powerful new tool for designers and implementers.