### PR TITLE
Fix and remove keyName_link

### DIFF
--- a/htdocs/xoops_lib/Xoops/Core/Kernel/Model/Joint.php
+++ b/htdocs/xoops_lib/Xoops/Core/Kernel/Model/Joint.php
@@ -183,7 +183,7 @@ class Joint extends XoopsModelAbstract
 
         $qb = $this->handler->db2->createXoopsQueryBuilder();
 
-        $qb ->select("l.{$this->handler->keyName_link}")
+        $qb ->select("l.{$this->handler->field_link}")
             ->addSelect('COUNT(*)')
             ->from($this->handler->table, 'o')
             ->leftJoin(
@@ -197,7 +197,7 @@ class Joint extends XoopsModelAbstract
             $criteria->renderQb($qb);
         }
 
-        $qb ->groupBy("l.{$this->handler->keyName_link}");
+        $qb ->groupBy("l.{$this->handler->field_link}");
 
         $result = $qb->execute();
 

--- a/htdocs/xoops_lib/Xoops/Core/Kernel/XoopsPersistableObjectHandler.php
+++ b/htdocs/xoops_lib/Xoops/Core/Kernel/XoopsPersistableObjectHandler.php
@@ -78,20 +78,15 @@ abstract class XoopsPersistableObjectHandler extends XoopsObjectHandler
      */
     public $identifierName;
 
-     /**
+    /**
      * @var string
      */
     public $field_link;
 
-     /**
-     * @var string
-     */
-    public $field_object;
-
     /**
      * @var string
      */
-    public $keyName_link;
+    public $field_object;
 
     /**
      * Constructor

--- a/tests/unit/xoopsLib/Xoops/Core/Kernel/Handlers/XoopsBlockHandlerTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/Kernel/Handlers/XoopsBlockHandlerTest.php
@@ -32,7 +32,6 @@ class BlockHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('name', $this->object->identifierName);
         $this->assertSame(null, $this->object->field_link);
         $this->assertSame(null, $this->object->field_object);
-        $this->assertSame(null, $this->object->keyName_link);
     }
 
     public function testContracts()

--- a/tests/unit/xoopsLib/Xoops/Core/Kernel/Model/JointTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/Kernel/Model/JointTest.php
@@ -49,7 +49,6 @@ class JointTest extends \PHPUnit_Framework_TestCase
         $handler->table_link=$this->conn->prefix('system_usergroup');
         $handler->field_link='groupid';
         $handler->field_object=$handler->field_link;
-        $handler->keyName_link=$handler->field_link;
 
         $result = $instance->getByLink(null, null, true, null, null);
         $this->assertTrue(is_array($result));
@@ -68,7 +67,6 @@ class JointTest extends \PHPUnit_Framework_TestCase
         $handler->table_link=$this->conn->prefix('system_usergroup');
         $handler->field_link='groupid';
         $handler->field_object=$handler->field_link;
-        $handler->keyName_link=$handler->field_link;
 
         $result = $instance->getCountByLink();
         $this->assertTrue(is_string($result));
@@ -87,7 +85,6 @@ class JointTest extends \PHPUnit_Framework_TestCase
         $handler->table_link=$this->conn->prefix('system_usergroup');
         $handler->field_link='groupid';
         $handler->field_object=$handler->field_link;
-        $handler->keyName_link=$handler->field_link;
 
         $result = $instance->getCountsByLink();
         $this->assertTrue(is_array($result));
@@ -106,7 +103,6 @@ class JointTest extends \PHPUnit_Framework_TestCase
         $handler->table_link=$this->conn->prefix('system_usergroup');
         $handler->field_link='groupid';
         $handler->field_object=$handler->field_link;
-        $handler->keyName_link=$handler->field_link;
 
         $criteria=new Xoops\Core\Kernel\Criteria('l.uid', 0);
         $arrData=array('name'=>'name');
@@ -127,7 +123,6 @@ class JointTest extends \PHPUnit_Framework_TestCase
         $handler->table_link=$this->conn->prefix('system_usergroup');
         $handler->field_link='groupid';
         $handler->field_object=$handler->field_link;
-        $handler->keyName_link=$handler->field_link;
 
         $criteria=new Xoops\Core\Kernel\Criteria('l.uid', 0);
 

--- a/tests/unit/xoopsLib/Xoops/Core/Kernel/XoopsPersistableObjectHandlerTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/Kernel/XoopsPersistableObjectHandlerTest.php
@@ -35,7 +35,7 @@ class XoopsPersistableObjectHandlerTest extends \PHPUnit_Framework_TestCase
     public function test___publicProperties()
     {
         $items = array('table', 'keyName', 'className', 'table_link', 'identifierName', 'field_link',
-            'field_object', 'keyName_link');
+            'field_object');
         foreach ($items as $item) {
             $prop = new ReflectionProperty($this->myClass, $item);
             $this->assertTrue($prop->isPublic());
@@ -174,7 +174,6 @@ class XoopsPersistableObjectHandlerTest extends \PHPUnit_Framework_TestCase
     public function test_getCountByLink()
     {
         $instance = new $this->myClass($this->conn, 'system_group', 'Xoops\Core\Kernel\Handlers\XoopsGroup', 'groupid', 'name');
-        $instance->keyName_link = 'gperm_name';
         $instance->field_object = 'groupid';
         $instance->table_link = $this->conn->prefix('system_permission');
         $instance->field_link = 'gperm_groupid';
@@ -185,7 +184,6 @@ class XoopsPersistableObjectHandlerTest extends \PHPUnit_Framework_TestCase
     public function test_getCountsByLink()
     {
         $instance = new $this->myClass($this->conn, 'system_group', 'Xoops\Core\Kernel\Handlers\XoopsGroup', 'groupid', 'name');
-        $instance->keyName_link = 'gperm_name';
         $instance->field_object = 'groupid';
         $instance->table_link = $this->conn->prefix('system_permission');
         $instance->field_link = 'gperm_groupid';


### PR DESCRIPTION
Xoops\Core\Kerne\Model\Joint.php used a keyName_link property which seems to have never been legitimate. This issue was flagged by zyspec in [XoopsCore25](https://github.com/XOOPS/XoopsCore25/issues/94), and these changes bring the two into alignment.