### PR TITLE
Updates and fixes

### DIFF
--- a/htdocs/modules/profile/register.php
+++ b/htdocs/modules/profile/register.php
@@ -206,7 +206,7 @@ if ($current_step > 0 && empty($stop) && (!empty($steps[$current_step - 1]['step
         $newuser->setVar('email', $email);
         $newuser->setVar('pass', $pass ? password_hash($pass, PASSWORD_DEFAULT) : '');
         $newuser->setVar('last_pass_change', time());
-        $actkey = substr(md5(uniqid(mt_rand(), 1)), 0, 8);
+        $actkey = substr(\Xmf\Random::generateKey(), 16, 8);
         $newuser->setVar('actkey', $actkey);
         $newuser->setVar('user_regdate', time());
         $newuser->setVar('uorder', $xoops->getConfig('com_order'));

--- a/htdocs/modules/smilies/class/SmiliesProvider.php
+++ b/htdocs/modules/smilies/class/SmiliesProvider.php
@@ -97,7 +97,7 @@ class SmiliesProvider extends AbstractContract implements EmojiInterface
     {
         $selector =  '<img src="' . \XoopsBaseConfig::get('url') . '/images/smiley.gif" alt="'
             . \XoopsLocale::SMILIES . '" title="' . \XoopsLocale::SMILIES . '" onclick=\'openWithSelfMain("'
-            . \XoopsBaseConfig::get('url') . '/modules/smilies/popup.php?target=' . $identifier
+            . \XoopsBaseConfig::get('url') . '/modules/smilies/include/popup.php?target=' . $identifier
             . '","smilies",300,650);\' onmouseover=\'style.cursor="hand"\'/>&nbsp;';
 
         $response->setValue($selector);

--- a/htdocs/modules/smilies/include/popup.php
+++ b/htdocs/modules/smilies/include/popup.php
@@ -22,7 +22,7 @@ use Xoops\Core\XoopsTpl;
  * @author          Mage Grégory (AKA Mage)
  */
 
-include dirname(dirname(__DIR__)) . '/mainfile.php';
+include dirname(dirname(dirname(__DIR__))) . '/mainfile.php';
 
 $xoops = Xoops::getInstance();
 $xoops->logger()->quiet();

--- a/htdocs/modules/system/blocks/user.php
+++ b/htdocs/modules/system/blocks/user.php
@@ -77,6 +77,7 @@ function b_system_user_show()
         'name' => XoopsLocale::EDIT_ACCOUNT,
         'link' => $xoops->url('edituser.php'),
         'icon' => 'glyphicon glyphicon-pencil',
+        'title' => XoopsLocale::EDIT_ACCOUNT,
     ));
 
     // Administration Menu
@@ -116,6 +117,7 @@ function b_system_user_show()
         'name' => XoopsLocale::A_LOGOUT,
         'link' => $xoops->url('user.php?op=logout'),
         'icon' => 'glyphicon glyphicon-log-out',
+        'title' => XoopsLocale::A_LOGOUT,
     ));
 
     $block['active_url'] = \Xoops\Core\HttpRequest::getInstance()->getUrl();

--- a/htdocs/modules/system/templates/blocks/system_block_login.tpl
+++ b/htdocs/modules/system/templates/blocks/system_block_login.tpl
@@ -10,7 +10,7 @@
         <div class="form-group">
             <label class="control-label" for="xo-login-pass">{$block.lang_password}</label>
             <div class="input-group">
-                <span class="input-group-addon"><span class="glyphicon glyphicon-question-sign"></span></span>
+                <span class="input-group-addon"><span class="glyphicon glyphicon-lock"></span></span>
                 <input class="form-control" type="password" name="pass" id="xo-login-pass">
             </div>
         </div>

--- a/htdocs/register.php
+++ b/htdocs/register.php
@@ -125,7 +125,7 @@ switch ($op) {
                 $newuser->setVar('url', $xoops->formatURL($url));
             }
             $newuser->setVar('user_avatar', 'blank.gif');
-            $actkey = substr(md5(uniqid(mt_rand(), 1)), 0, 8);
+            $actkey = substr(\Xmf\Random::generateKey(), 16, 8);
             $newuser->setVar('actkey', $actkey);
             $newuser->setVar('pass', password_hash($pass, PASSWORD_DEFAULT));
             $newuser->setVar('last_pass_change', time());

--- a/htdocs/xoops_lib/Xoops.php
+++ b/htdocs/xoops_lib/Xoops.php
@@ -1230,11 +1230,9 @@ class Xoops
             echo '<link rel="stylesheet" type="text/css" media="all" href="' . $xoops_url
                 . '/locale/' . $locale . '/style.css" />';
         }
+        $themecss = $this->getCss($this->getConfig('theme_set'));
         if ($themecss) {
             echo '<link rel="stylesheet" type="text/css" media="all" href="' . $themecss . '" />';
-            echo '<link rel="stylesheet" type="text/css" media="screen" href="' .
-                $this->url('themes/' . $this->getConfig('theme_set') . '/media/bootstrap/css/xoops.bootstrap.css')
-                .'" />';
         }
         if ($closehead) {
             echo '</head><body>';

--- a/htdocs/xoops_lib/Xoops/Core/Text/Sanitizer.php
+++ b/htdocs/xoops_lib/Xoops/Core/Text/Sanitizer.php
@@ -280,7 +280,7 @@ class Sanitizer extends SanitizerConfigurable
         if (!(bool) $html) {
             // html not allowed, so escape any special chars
             // don't mess with quotes or shortcodes will fail
-            $text = htmlspecialchars($text, ENT_NOQUOTES);
+            $text = htmlspecialchars($text, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
         }
 
         if ($xcode) {

--- a/htdocs/xoops_lib/Xoops/Core/Text/Sanitizer.php
+++ b/htdocs/xoops_lib/Xoops/Core/Text/Sanitizer.php
@@ -181,7 +181,7 @@ class Sanitizer extends SanitizerConfigurable
      */
     public function htmlSpecialChars($text, $quote_style = ENT_QUOTES)
     {
-        $text = htmlspecialchars($text, $quote_style | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $text = htmlspecialchars($text, $quote_style | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
         return $text;
     }
 

--- a/htdocs/xoops_lib/composer.json
+++ b/htdocs/xoops_lib/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.8",
-        "phpunit/phpunit-skeleton-generator": "*"
+        "codeception/codeception": "^2.1"
     },
     "extra": {
         "xoops_modules_path": "../modules/"

--- a/htdocs/xoops_lib/composer.json.dist
+++ b/htdocs/xoops_lib/composer.json.dist
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.8",
-        "phpunit/phpunit-skeleton-generator": "*"
+        "codeception/codeception": "^2.1"
     },
     "extra": {
         "xoops_modules_path": "../modules/"

--- a/tests/unit/class/module.textsanitizerTest.php
+++ b/tests/unit/class/module.textsanitizerTest.php
@@ -258,7 +258,7 @@ class ModuleMyTextSanitizerTest extends \PHPUnit_Framework_TestCase
 
         $text = 'toto&nbsp;titi';
         $message = $sanitizer->htmlSpecialChars($text);
-        $this->assertSame('toto&amp;nbsp;titi',$message);
+        $this->assertSame('toto&nbsp;titi',$message);
     }
 
     public function test_undohtmlSpecialChars()

--- a/tests/unit/xoopsLib/Xoops/Core/Text/SanitizerTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/Text/SanitizerTest.php
@@ -140,7 +140,7 @@ class SanitizerTest extends \PHPUnit_Framework_TestCase
 
         $text = 'toto&nbsp;titi';
         $message = $this->object->htmlSpecialChars($text);
-        $this->assertSame('toto&amp;nbsp;titi',$message);
+        $this->assertSame('toto&nbsp;titi',$message);
     }
 
     /**


### PR DESCRIPTION
- Removed phpunit/phpunit-skeleton-generator from composer.json require-dev. The package was recently marked "This project has been abandoned and is no longer maintained." Recommend using the phar version from https://phar.phpunit.de/phpunit-skelgen-2.0.1.phar if needed.
- Added codeception to composer.json require-dev.
- Remove mt_rand() from activation key generation.
- Make smilies selector popup available to non-admin users.
- Other small fixes.