### PR TITLE
Testing .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - 7.1.0beta1
+  - 7.1
   - hhvm
 
 matrix:
     allow_failures:
         - php: hhvm
-        - php: 7.1.0beta1
+        - php: 7.1
 
 before_install:
   - composer self-update
@@ -32,5 +32,5 @@ script:
   - htdocs/xoops_lib/vendor/bin/phpunit
 
 after_script:
-  - if [ "$TRAVIS_PHP_VERSION" != "7.1.0beta1" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" != "7.1.0beta1" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "7.1" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "7.1" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/htdocs/modules/comments/class/form/comment.php
+++ b/htdocs/modules/comments/class/form/comment.php
@@ -157,6 +157,5 @@ class CommentsCommentForm extends Xoops\Form\ThemeForm
         $buttonTray->addElement(new Xoops\Form\Button('', 'com_dopreview', XoopsLocale::A_PREVIEW, 'submit'));
         $buttonTray->addElement(new Xoops\Form\Button('', 'com_dopost', _MD_COMMENTS_POSTCOMMENT, 'submit'));
         $this->addElement($buttonTray);
-        return $this;
     }
 }

--- a/htdocs/modules/debugbar/class/debugbarlogger.php
+++ b/htdocs/modules/debugbar/class/debugbarlogger.php
@@ -99,7 +99,7 @@ class DebugbarLogger implements LoggerInterface
     /**
      * Enable logger output rendering
      * When output rendering is enabled, the logger will insert its output within the page content.
-     * If the string <!--{xo-logger-output}--> is found in the page content, the logger output will
+     * If the string <!--<xo-logger-output>--> is found in the page content, the logger output will
      * replace it, otherwise it will be inserted after all the page output.
      *
      * @return void
@@ -398,7 +398,7 @@ class DebugbarLogger implements LoggerInterface
     /**
      * Enable logger output rendering
      * When output rendering is enabled, the logger will insert its output within the page content.
-     * If the string <!--{xo-logger-output}--> is found in the page content, the logger output will
+     * If the string <!--<xo-logger-output>--> is found in the page content, the logger output will
      * replace it, otherwise it will be inserted after all the page output.
      *
      * @return void
@@ -428,7 +428,7 @@ class DebugbarLogger implements LoggerInterface
         $log = $this->renderer->render();
         $this->renderingEnabled = $this->activated = false;
 
-        $pattern = '<!--{xo-logger-output}-->';
+        $pattern = '<!--<xo-logger-output>-->';
         $pos = strpos($output, $pattern);
         if ($pos !== false) {
             return substr($output, 0, $pos) . $log . substr($output, $pos + strlen($pattern));

--- a/htdocs/modules/logger/class/legacylogger.php
+++ b/htdocs/modules/logger/class/legacylogger.php
@@ -112,9 +112,9 @@ class LegacyLogger implements LoggerInterface
 
     /**
      * Save a copy of our config array
-     * 
+     *
      * @param array $configs array of module/user config options
-     * 
+     *
      * @return void
      */
     public function setConfigs($configs)
@@ -124,7 +124,7 @@ class LegacyLogger implements LoggerInterface
 
     /**
      * disable logging
-     * 
+     *
      * @return void
      */
     public function disable()
@@ -136,9 +136,9 @@ class LegacyLogger implements LoggerInterface
     /**
      * Enable logger output rendering
      * When output rendering is enabled, the logger will insert its output within the page content.
-     * If the string <!--{xo-logger-output}--> is found in the page content, the logger output will
+     * If the string <!--<xo-logger-output>--> is found in the page content, the logger output will
      * replace it, otherwise it will be inserted after all the page output.
-     * 
+     *
      * @return void
      */
     public function enable()
@@ -156,7 +156,7 @@ class LegacyLogger implements LoggerInterface
 
     /**
      * report enabled status
-     * 
+     *
      * @return bool
      */
     public function isEnable()
@@ -166,7 +166,7 @@ class LegacyLogger implements LoggerInterface
 
     /**
      * disable output for the benefit of ajax scripts
-     * 
+     *
      * @return void
      */
     public function quiet()
@@ -176,7 +176,7 @@ class LegacyLogger implements LoggerInterface
 
     /**
      * Add our resources to the theme as soon as it is available, otherwise return
-     * 
+     *
      * @return void
      */
     private function addToTheme()
@@ -200,7 +200,7 @@ class LegacyLogger implements LoggerInterface
      * Start a timer
      *
      * @param string $name name of the timer
-     * 
+     *
      * @return void
      */
     public function startTime($name = 'XOOPS')
@@ -214,7 +214,7 @@ class LegacyLogger implements LoggerInterface
      * Stop a timer
      *
      * @param string $name name of the timer
-     * 
+     *
      * @return void
      */
     public function stopTime($name = 'XOOPS')
@@ -249,7 +249,7 @@ class LegacyLogger implements LoggerInterface
      * @param string $name      name of the block
      * @param bool   $cached    was the block cached?
      * @param int    $cachetime cachetime of the block
-     * 
+     *
      * @return void
      */
     public function addBlock($name, $cached = false, $cachetime = 0)
@@ -264,7 +264,7 @@ class LegacyLogger implements LoggerInterface
      *
      * @param string $name name for the entry
      * @param string $msg  text message for the entry
-     * 
+     *
      * @return void
      */
     public function addExtra($name, $msg)
@@ -278,7 +278,7 @@ class LegacyLogger implements LoggerInterface
      * Log messages for deprecated functions
      *
      * @param string $msg name for the entry
-     * 
+     *
      * @return void
      */
     public function addDeprecated($msg)
@@ -292,7 +292,7 @@ class LegacyLogger implements LoggerInterface
      * Log exceptions
      *
      * @param Exception $e name for the entry
-     * 
+     *
      * @return void
      */
     public function addException($e)
@@ -308,9 +308,9 @@ class LegacyLogger implements LoggerInterface
 
     /**
      * sanitizePath
-     * 
-     * @param string $path path name to sanitize 
-     * 
+     *
+     * @param string $path path name to sanitize
+     *
      * @return string path with top levels removed
      */
     public function sanitizePath($path)
@@ -330,9 +330,9 @@ class LegacyLogger implements LoggerInterface
     /**
      * Enable logger output rendering
      * When output rendering is enabled, the logger will insert its output within the page content.
-     * If the string <!--{xo-logger-output}--> is found in the page content, the logger output will
+     * If the string <!--<xo-logger-output>--> is found in the page content, the logger output will
      * replace it, otherwise it will be inserted after all the page output.
-     * 
+     *
      * @return void
      */
     public function enableRendering()
@@ -345,9 +345,9 @@ class LegacyLogger implements LoggerInterface
 
     /**
      * Output buffering callback inserting logger dump in page output
-     * 
+     *
      * @param string $output output buffer to add logger rendering to
-     * 
+     *
      * @return string output
      */
     public function render($output)
@@ -359,7 +359,7 @@ class LegacyLogger implements LoggerInterface
         $log = $this->dump($this->usePopup ? 'popup' : '');
         $this->renderingEnabled = $this->activated = false;
 
-        $pattern = '<!--{xo-logger-output}-->';
+        $pattern = '<!--<xo-logger-output>-->';
         $pos = strpos($output, $pattern);
         if ($pos !== false) {
             return substr($output, 0, $pos) . $log . substr($output, $pos + strlen($pattern));
@@ -370,9 +370,9 @@ class LegacyLogger implements LoggerInterface
 
     /**
      * Dump output
-     * 
+     *
      * @param string $mode unused
-     * 
+     *
      * @return string output
      */
     public function dump($mode = '')
@@ -425,14 +425,14 @@ class LegacyLogger implements LoggerInterface
         foreach ($included_files as $filename) {
             $this->addExtra('files',$filename);
         }
-        
+
         if (function_exists('memory_get_peak_usage')) {
             $this->addExtra('Peak memory',memory_get_peak_usage());
         }
         */
 
         $memory = 0;
-        
+
         if (function_exists('memory_get_usage')) {
             $memory = memory_get_usage() . ' bytes';
         } else {
@@ -461,7 +461,7 @@ class LegacyLogger implements LoggerInterface
             $ret .= "<a href='javascript:xoSetLoggerView(\"timers\")'>" . _MD_LOGGER_TIMERS . "($count)</a>\n";
             $ret .= "</div>\n";
         }
-        
+
         if (empty($mode) || $mode === 'errors') {
             $class = 'even';
             $ret .= '<table id="xo-logger-errors" class="outer"><thead><tr><th>' . _MD_LOGGER_ERRORS . '</th></tr></thead><tbody>';
@@ -490,17 +490,17 @@ class LegacyLogger implements LoggerInterface
             $class = 'even';
             $ret .= '<table id="xo-logger-queries" class="outer"><thead><tr><th>' . _MD_LOGGER_QUERIES . '</th></tr></thead><tbody>';
             $pattern = '/\b' . preg_quote(\XoopsBaseConfig::get('db-prefix')) . '\_/i';
-        
+
             foreach ($this->queries as $q) {
                 $sql = preg_replace($pattern, '', $q['sql']);
                 $query_time = isset($q['query_time']) ? sprintf('%0.6f - ', $q['query_time']) : '';
-        
+
                 if (isset($q['error'])) {
                     $ret .= '<tr class="' . $class . '"><td><span style="color:#ff0000;">' . $query_time . htmlentities($sql) . '<br /><strong>Error number:</strong> ' . $q['errno'] . '<br /><strong>Error message:</strong> ' . $q['error'] . '</span></td></tr>';
                 } else {
                     $ret .= '<tr class="' . $class . '"><td>' . $query_time . htmlentities($sql) . '</td></tr>';
                 }
-        
+
                 $class = ($class === 'odd') ? 'even' : 'odd';
             }
             $ret .= '</tbody><tfoot><tr class="foot"><td>' . _MD_LOGGER_TOTAL . ': <span style="color:#ff0000;">' . count($this->queries) . '</span></td></tr></tfoot></table>';
@@ -540,7 +540,7 @@ class LegacyLogger implements LoggerInterface
             }
             $ret .= '</tbody></table>';
         }
-        
+
         if (empty($mode)) {
             $ret .= <<<EOT
 </div>
@@ -622,7 +622,7 @@ EOT;
      *
      * @param string $message message
      * @param array  $context array of additional context
-     * 
+     *
      * @return null
      */
     public function emergency($message, array $context = array())
@@ -640,7 +640,7 @@ EOT;
      *
      * @param string $message message
      * @param array  $context array of additional context
-     * 
+     *
      * @return null
      */
     public function alert($message, array $context = array())
@@ -657,7 +657,7 @@ EOT;
      *
      * @param string $message message
      * @param array  $context array of additional context
-     * 
+     *
      * @return null
      */
     public function critical($message, array $context = array())
@@ -673,7 +673,7 @@ EOT;
      *
      * @param string $message message
      * @param array  $context array of additional context
-     * 
+     *
      * @return null
      */
     public function error($message, array $context = array())
@@ -691,7 +691,7 @@ EOT;
      *
      * @param string $message message
      * @param array  $context array of additional context
-     * 
+     *
      * @return null
      */
     public function warning($message, array $context = array())
@@ -706,7 +706,7 @@ EOT;
      *
      * @param string $message message
      * @param array  $context array of additional context
-     * 
+     *
      * @return null
      */
     public function notice($message, array $context = array())
@@ -723,7 +723,7 @@ EOT;
      *
      * @param string $message message
      * @param array  $context array of additional context
-     * 
+     *
      * @return null
      */
     public function info($message, array $context = array())
@@ -738,7 +738,7 @@ EOT;
      *
      * @param string $message message
      * @param array  $context array of additional context
-     * 
+     *
      * @return null
      */
     public function debug($message, array $context = array())
@@ -754,7 +754,7 @@ EOT;
      * @param mixed  $level   logging level
      * @param string $message message
      * @param array  $context array of additional context
-     * 
+     *
      * @return null
      */
     public function log($level, $message, array $context = array())

--- a/htdocs/modules/system/themes/default/theme.tpl
+++ b/htdocs/modules/system/themes/default/theme.tpl
@@ -25,10 +25,11 @@
     <div class="text-center">
         Powered by <a href="https://github.com/XOOPS" rel="external" title="Xoops Project"><{$xoops_version}></a> &copy; 2001-<{$smarty.now|date_format:"%Y"}>
     </div>
-    <!--{xo-logger-output}-->
+    <!--<xo-logger-output>-->
 </div>
 <script type="text/javascript">
     ddsmoothmenu.init( { mainmenuid:"xo-menu-modules", orientation:'h', classname:'ddsmoothmenu', contentsource:"markup" } )
 </script>
 </body>
 </html>
+

--- a/htdocs/themes/defaultbs2/theme.tpl
+++ b/htdocs/themes/defaultbs2/theme.tpl
@@ -143,7 +143,7 @@
                     <div class="pagination-centered">
                         <{$xoops_footer}>
                     </div>
-                    <!--{xo-logger-output}-->
+                    <!--<xo-logger-output>-->
                 </div>
             </div>
         </div>

--- a/htdocs/xoops_lib/Xmf/Metagen.php
+++ b/htdocs/xoops_lib/Xmf/Metagen.php
@@ -141,7 +141,7 @@ class Metagen
         }
 
         $originalKeywords = preg_split(
-            '/[^a-zA-Z\'"-]+/',
+            '/[^\w\']+/u',
             $text,
             -1,
             PREG_SPLIT_NO_EMPTY

--- a/htdocs/xoops_lib/Xoops/Core/Database/Logging/XoopsDebugStack.php
+++ b/htdocs/xoops_lib/Xoops/Core/Database/Logging/XoopsDebugStack.php
@@ -28,16 +28,33 @@ use Doctrine\DBAL\Logging\DebugStack;
 class XoopsDebugStack extends DebugStack
 {
     /**
+     * Logs a SQL statement somewhere.
+     *
+     * @param string $sql The SQL to be executed.
+     * @param array $params The SQL parameters.
+     * @param array $types The SQL parameter types.
+     * @return void
+     */
+    public function startQuery($sql, array $params = null, array $types = null)
+    {
+        \Xoops::getInstance()->events()->triggerEvent(
+            'core.database.query.begin',
+            [$sql, $params, $types]
+        );
+        parent::startQuery($sql, $params, $types);
+    }
+
+    /**
      * stopQuery
-     * 
+     *
      * Perform usual Doctrine DebugStack stopQuery() and trigger event for loggers
-     * 
+     *
      * Event argument is array:
      *   - 'sql'         => string SQL statement
      *   - 'params'      => array of bound parameters
      *   - 'types'       => array of parameter types
      *   - 'executionMS' => float of execution time in microseconds
-     * 
+     *
      * @return void
      */
     public function stopQuery()

--- a/htdocs/xoops_lib/Xoops/Core/Session/Handler.php
+++ b/htdocs/xoops_lib/Xoops/Core/Session/Handler.php
@@ -164,7 +164,8 @@ class Handler implements \SessionHandlerInterface
             ->setParameter(':sessid', $session_id, \PDO::PARAM_STR);
         $this->db->setForce(true);
         $result = $qb->execute();
-        return (boolean) ($result>0);
+        //return (boolean) ($result>0);
+        return true;
     }
 
     /**

--- a/tests/unit/xoopsLib/Xoops/Core/Handler/Scheme/SchemeInterfaceTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/Handler/Scheme/SchemeInterfaceTest.php
@@ -27,8 +27,15 @@ class SchemeInterfaceTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        if (version_compare(phpversion(), '7.1.0beta3', '=')) {
+            //var_dump(phpversion());
+            $this->markTestSkipped('segfault on mock access?');
+        }
+
         if (method_exists($this, 'createMock')) {
             $this->object = $this->createMock('\Xoops\Core\Handler\Scheme\SchemeInterface');
+            $this->object->method('build')
+                ->willReturn(null);
         } else { // need phpunit 4.8 for PHP 5.5
             $this->object = $this->getMock('\Xoops\Core\Handler\Scheme\SchemeInterface');
         }


### PR DESCRIPTION
- testing 7.1.0beta3
- skip tests/unit/xoopsLib/Xoops/Core/Handler/Scheme/SchemeInterfaceTest.php under 7.1.0beta3 *(PHPUnit 5.5.2 segfaults when processing createMock on SchemeInterface)*
- remove spurious "return $this;" from \CommentsCommentForm::__construct()
- tweak to Xoops\Core\Database\Logging\XoopsDebugStack harmlessly included in error
- fix warning from session manager