### PR TITLE
Issue with Xmf\Yaml::readWrapped()

### DIFF
--- a/htdocs/xoops_lib/Xmf/Yaml.php
+++ b/htdocs/xoops_lib/Xmf/Yaml.php
@@ -157,9 +157,22 @@ class Yaml
     public static function loadWrapped($yamlString)
     {
         try {
-            $match = array();
-            $matched = preg_match('/(---.*\.\.\.)/s', $yamlString, $match);
-            $unwrapped = $matched ? $match[1] : $yamlString;
+            $lines = preg_split('/\R/', $yamlString);
+            $count = count($lines);
+            for ($index = $count; --$index > 0;) {
+                if ('...' === $lines[$index]) {
+                    array_splice($lines, $index);
+                    break;
+                }
+            }
+            $count = count($lines);
+            for ($index = 0; ++$index < $count;) {
+                if ('---' === $lines[$index]) {
+                    array_splice($lines, 0, $index);
+                    break;
+                }
+            }
+            $unwrapped = implode("\n", $lines);
             $ret = VendorYaml::parse($unwrapped);
         } catch (\Exception $e) {
             static::logError($e);

--- a/tests/unit/xoopsLib/Xmf/YamlTest.php
+++ b/tests/unit/xoopsLib/Xmf/YamlTest.php
@@ -81,6 +81,40 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Xmf\Yaml::dumpWrapped
+     * @covers Xmf\Yaml::loadWrapped
+     */
+    public function testDumpAndLoadWrappedStress()
+    {
+        $inputArray = array('start' => '---', 'end' => '...', 'misc' => 'stuff');
+
+        $string = Yaml::dumpWrapped($inputArray);
+        $this->assertTrue(!empty($string));
+        $this->assertTrue(is_string($string));
+
+        $outputArray = Yaml::loadWrapped((string) $string);
+        $this->assertTrue(is_array($outputArray));
+        $this->assertSame($inputArray, $outputArray);
+    }
+
+    /**
+     * @covers Xmf\Yaml::dumpWrapped
+     * @covers Xmf\Yaml::loadWrapped
+     */
+    public function testDumpAndLoadWrappedStress2()
+    {
+        $inputArray = array('start' => '---', 'end' => '...', 'misc' => 'stuff');
+
+        $string = Yaml::dump($inputArray);
+        $this->assertTrue(!empty($string));
+        $this->assertTrue(is_string($string));
+
+        $outputArray = Yaml::loadWrapped((string) $string);
+        $this->assertTrue(is_array($outputArray));
+        $this->assertSame($inputArray, $outputArray);
+    }
+
+    /**
      * @covers Xmf\Yaml::saveWrapped
      * @covers Xmf\Yaml::readWrapped
      */


### PR DESCRIPTION
See XOOPS/xmf#19

- Add test to catch failing inputs
- Correct readWrapped() error