### PR TITLE
System module Help

### DIFF
--- a/htdocs/modules/system/help.php
+++ b/htdocs/modules/system/help.php
@@ -119,6 +119,17 @@ if ($mid > 0) {
                 \XoopsBaseConfig::get('root-path') . '/modules/' . $module->getVar('dirname', 'e')
                 . '/language/' . $xoopsConfig['language'] . '/help/' . $page . '.html'
             );
+        } elseif ($helpfile =
+            XoopsLoad::fileExists(
+                \XoopsBaseConfig::get('root-path') . '/modules/' . $module->getVar('dirname', 'e')
+                . '/locale/en_US/help/' . $page . '.html'
+            )
+        ) {
+            $helpcontent =
+                $xoops->tpl()->fetch(
+                    \XoopsBaseConfig::get('root-path') . '/modules/' . $module->getVar('dirname', 'e')
+                    . '/locale/en_US/help/' . $page . '.html'
+                );
         } else {
             if (XoopsLoad::fileExists(
                 \XoopsBaseConfig::get('root-path') . '/modules/' . $module->getVar('dirname', 'e')


### PR DESCRIPTION
No fallback for Help file. 

Is there a way to get the locale from configs like $xoopsConfig['language'] ?
I ask this because strangely, XoopsLocale::getLocale() does not return the configuration from database. It is getting the locale from my browser. It is not the behavior we should expect for help files, is it?