### PR TITLE
Fix issues with Xmf\Request::MASK_ALLOW_HTML

### DIFF
--- a/htdocs/xoops_lib/Xmf/FilterInput.php
+++ b/htdocs/xoops_lib/Xmf/FilterInput.php
@@ -169,8 +169,8 @@ class FilterInput
     }
 
     /**
-     * Method to be called by another php script. Processes for XSS and
-     * specified bad code.
+     * Static method to be called by another php script.
+     * Clean the supplied input using the default filter
      *
      * @param mixed  $source Input string/array-of-string to be 'cleaned'
      * @param string $type   Return/cleaning type for the variable, one of
@@ -190,6 +190,24 @@ class FilterInput
             $filter = static::getInstance();
         }
 
+        return $filter->cleanVar($source, $type);
+    }
+
+    /**
+     * Method to be called by another php script. Processes for XSS and
+     * specified bad code according to rules supplied when this instance
+     * was instantiated.
+     *
+     * @param mixed  $source Input string/array-of-string to be 'cleaned'
+     * @param string $type   Return/cleaning type for the variable, one of
+     *                       (INTEGER, FLOAT, BOOLEAN, WORD, ALPHANUM, CMD, BASE64,
+     *                        STRING, ARRAY, PATH, USERNAME, WEBURL, EMAIL, IP)
+     *
+     * @return mixed 'Cleaned' version of input parameter
+     * @static
+     */
+    public function cleanVar($source, $type = 'string')
+    {
         // Handle the type constraint
         switch (strtoupper($type)) {
             case 'INT':
@@ -230,11 +248,11 @@ class FilterInput
                 break;
 
             case 'STRING':
-                $result = (string) $filter->process($source);
+                $result = (string) $this->process($source);
                 break;
 
             case 'ARRAY':
-                $result = (array) $filter->process($source);
+                $result = (array) $this->process($source);
                 break;
 
             case 'PATH':
@@ -249,7 +267,7 @@ class FilterInput
                 break;
 
             case 'WEBURL':
-                $result = (string) $filter->process($source);
+                $result = (string) $this->process($source);
                 // allow only relative, http or https
                 $urlparts = parse_url($result);
                 if (!empty($urlparts['scheme'])
@@ -280,7 +298,7 @@ class FilterInput
                 break;
 
             default:
-                $result = $filter->process($source);
+                $result = $this->process($source);
                 break;
         }
 

--- a/htdocs/xoops_lib/Xmf/Request.php
+++ b/htdocs/xoops_lib/Xmf/Request.php
@@ -583,7 +583,7 @@ class Request
                 if (null === $safeHtmlFilter) {
                     $safeHtmlFilter = FilterInput::getInstance(array(), array(), 1, 1);
                 }
-                $var = $safeHtmlFilter->clean($var, $type);
+                $var = $safeHtmlFilter->cleanVar($var, $type);
             } else {
                 // Since no allow flags were set, we will apply the most strict filter to the variable
                 if (null === $noHtmlFilter) {

--- a/tests/unit/xoopsLib/Xmf/FilterInputTest.php
+++ b/tests/unit/xoopsLib/Xmf/FilterInputTest.php
@@ -87,6 +87,39 @@ class FilterInputTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Xmf\FilterInput::cleanVar
+     */
+    public function testCleanVarDefault()
+    {
+        $filter = FilterInput::getInstance();
+        $safeTest = '<p>This is a <em>simple</em> test.</p>';
+        $this->assertEquals('This is a simple test.', $filter->cleanVar($safeTest));
+    }
+
+    /**
+     * @covers Xmf\FilterInput::cleanVar
+     */
+    public function testCleanVarFilter()
+    {
+        $filter = FilterInput::getInstance(array(), array(), 1, 1);
+
+        $safeTest = '<p>This is a <em>simple</em> test.</p>';
+        $this->assertEquals($safeTest, $filter->cleanVar($safeTest));
+    }
+
+    /**
+     * @covers Xmf\FilterInput::cleanVar
+     */
+    public function testCleanVarFilterXss()
+    {
+        $filter = FilterInput::getInstance(array(), array(), 1, 1);
+
+        $xssTest = '<p>This is a <em>xss</em> <script>alert();</script> test.</p>';
+        $xssTestExpect = '<p>This is a <em>xss</em> alert(); test.</p>';
+        $this->assertEquals($xssTestExpect, $filter->cleanVar($xssTest));
+    }
+
+    /**
      * @covers Xmf\FilterInput::gather
      */
     public function testGather()

--- a/tests/unit/xoopsLib/Xmf/RequestTest.php
+++ b/tests/unit/xoopsLib/Xmf/RequestTest.php
@@ -176,6 +176,45 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Xmf\Request::getString
+     */
+    public function testGetString2()
+    {
+        $varname = 'RequestTest';
+
+        $safeTest = '<p>This is a <em>simple</em> test.</p>';
+        $_POST[$varname] = $safeTest;
+
+        $this->assertEquals('This is a simple test.', Request::getString($varname, '', 'POST'));
+    }
+
+    /**
+     * @covers Xmf\Request::getString
+     */
+    public function testGetStringAllowHtml()
+    {
+        $varname = 'RequestTest';
+
+        $safeTest = '<p>This is a <em>simple</em> test.</p>';
+        $_POST[$varname] = $safeTest;
+
+        $this->assertEquals($safeTest, Request::getString($varname, '', 'POST', Request::MASK_ALLOW_HTML));
+    }
+
+    /**
+     * @covers Xmf\Request::getString
+     */
+    public function testGetStringAllowHtmlXss()
+    {
+        $varname = 'RequestTest';
+
+        $xssTest = '<p>This is a <em>xss</em> <script>alert();</script> test.</p>';
+        $_POST[$varname] = $xssTest;
+        $xssTestExpect = '<p>This is a <em>xss</em> alert(); test.</p>';
+        $this->assertEquals($xssTestExpect, Request::getString($varname, '', 'POST', Request::MASK_ALLOW_HTML));
+    }
+
+    /**
      * @covers Xmf\Request::getArray
      */
     public function testGetArray()


### PR DESCRIPTION
FilterInput::clean() always filters HTML, thus ignoring the MASK_ALLOW_HTML if specified in Request.

- Add failing test for issue
- Non-configurable static clean() method documented as using default filter.
- Adds non static cleanVar() method that respects instantiated filters.
- Add tests for new method