### PR TITLE
Issues in Xmf\Highlighter, Xmf\Metagen

### DIFF
--- a/htdocs/xoops_lib/Xmf/Highlighter.php
+++ b/htdocs/xoops_lib/Xmf/Highlighter.php
@@ -44,7 +44,7 @@ class Highlighter
     public static function apply($words, $body, $pre = '<mark>', $post = '</mark>')
     {
         if (!is_array($words)) {
-            $words = str_replace('  ', ' ', $words);
+            $words = preg_replace('/[\s]+/', ' ', $words);
             $words = explode(' ', $words);
         }
         foreach ($words as $word) {
@@ -78,7 +78,7 @@ class Highlighter
                     while ($p1 !== false) {
                         $ret .= mb_substr($haystack, 0, $p1, $encoding) . $pre
                             . mb_substr($haystack, $p1, $l1, $encoding) . $post;
-                        $haystack = mb_substr($haystack, $p1 + $l1, null, $encoding);
+                        $haystack = mb_substr($haystack, $p1 + $l1, mb_strlen($haystack), $encoding);
                         $p1 = mb_stripos($haystack, $needle, 0, $encoding);
                     }
                 } else {

--- a/htdocs/xoops_lib/Xmf/Metagen.php
+++ b/htdocs/xoops_lib/Xmf/Metagen.php
@@ -310,7 +310,7 @@ class Metagen
                 // we are not at the beginning so find first blank
                 $temp = mb_strpos($haystack, ' ', $start, static::ENCODING);
                 $start = ($temp === false) ? $start : $temp;
-                $haystack = mb_substr($haystack, $start, null, static::ENCODING);
+                $haystack = mb_substr($haystack, $start, mb_strlen($haystack), static::ENCODING);
             }
 
             $post = !(mb_strlen($haystack, static::ENCODING) < $length); // need an ellipsis in back?

--- a/tests/unit/xoopsLib/Xmf/HighlighterTest.php
+++ b/tests/unit/xoopsLib/Xmf/HighlighterTest.php
@@ -50,6 +50,9 @@ class HighlighterTest extends \PHPUnit_Framework_TestCase
         $output = Highlighter::apply(array('test','ok'), 'This test is OK.', '<i>', '</i>');
         $this->assertEquals($output, 'This <i>test</i> is <i>OK</i>.');
 
+        $output = Highlighter::apply(array('test    ok'), 'This test is OK.', '<i>', '</i>');
+        $this->assertEquals($output, 'This <i>test</i> is <i>OK</i>.');
+
         $output = Highlighter::apply(array('test','ok'), 'This test <test>is</test> OK.', '<i>', '</i>');
         $this->assertEquals($output, 'This <i>test</i> <test>is</test> <i>OK</i>.');
     }

--- a/tests/unit/xoopsLib/Xmf/HighlighterTest.php
+++ b/tests/unit/xoopsLib/Xmf/HighlighterTest.php
@@ -45,15 +45,15 @@ class HighlighterTest extends \PHPUnit_Framework_TestCase
     public function testApply()
     {
         $output = Highlighter::apply('test', 'This test is OK.');
-        $this->assertEquals($output, 'This <mark>test</mark> is OK.');
+        $this->assertEquals('This <mark>test</mark> is OK.', $output);
 
         $output = Highlighter::apply(array('test','ok'), 'This test is OK.', '<i>', '</i>');
-        $this->assertEquals($output, 'This <i>test</i> is <i>OK</i>.');
+        $this->assertEquals('This <i>test</i> is <i>OK</i>.', $output);
 
-        $output = Highlighter::apply(array('test    ok'), 'This test is OK.', '<i>', '</i>');
-        $this->assertEquals($output, 'This <i>test</i> is <i>OK</i>.');
+        $output = Highlighter::apply('test    ok', 'This test is OK.', '<i>', '</i>');
+        $this->assertEquals('This <i>test</i> is <i>OK</i>.', $output);
 
         $output = Highlighter::apply(array('test','ok'), 'This test <test>is</test> OK.', '<i>', '</i>');
-        $this->assertEquals($output, 'This <i>test</i> <test>is</test> <i>OK</i>.');
+        $this->assertEquals('This <i>test</i> <test>is</test> <i>OK</i>.', $output);
     }
 }


### PR DESCRIPTION
- parsing error for space delimited words list
- work around old mb_substr() bug

Addresses XOOPS/xmf#33 and XOOPS/xmf#34