### PR TITLE
Fixed Directory Traversal issue on jquery.php.

### DIFF
--- a/htdocs/modules/system/admin/tplsets/jquery.php
+++ b/htdocs/modules/system/admin/tplsets/jquery.php
@@ -29,6 +29,10 @@ if (!$xoops->isUser() || !$xoops->isModule() || !$xoops->user->isAdmin($xoops->m
     exit(XoopsLocale::E_NO_ACCESS_PERMISSION);
 }
 
+if (isset($_REQUEST['dir']) && strpos($_REQUEST['dir'],'..') !== false || isset($_REQUEST['path_file']) && strpos($_REQUEST['path_file'],'..') !== false) {
+    exit(XoopsLocale::E_NO_ACCESS_PERMISSION);
+}
+
 include_once $xoops->path('modules/system/functions.php');
 $xoops->loadLocale('system');
 


### PR DESCRIPTION
**Description**
Template viewer on `http://[server name]/[base path]/modules/system/admin.php?fct=tplsets` allows malicious user to read restricted files outside of the web server’s root directory such as `/etc/passwd/`.
This viewer is restricted to admin but must return permission error when users try to access restricted files and directories.

**Screenshot**
![image](https://user-images.githubusercontent.com/7601382/31024828-44895da2-a57b-11e7-8094-5939c93e0d65.png)

If i have to describe how to reproduce this issue, please let me know.