### PR TITLE
Tweak travis.yml and test errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 
 script:
   - xoops_lib/vendor/bin/phpunit
-  - wget https://github.com/diff-sniffer/git/releases/download/0.1.0/git-phpcs.phar
+  - wget https://github.com/diff-sniffer/git/releases/download/0.2.0/git-phpcs.phar
   - php git-phpcs.phar origin/$TRAVIS_BRANCH...$TRAVIS_PULL_REQUEST_SHA
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,22 +14,23 @@ php:
 
 before_install:
   - composer self-update
+  - cp composer.json.dist composer.json
 
 install:
-  - composer --working-dir=htdocs/xoops_lib/ install
-  - wget https://github.com/diff-sniffer/git/releases/download/0.2.0/git-phpcs.phar
+  - composer require xoops/base-requires:dev-master
+  - composer update
 
 before_script:
   - mysql -e 'create database xoops_test;'
   - php console/console.php ci-bootstrap
   - php console/console.php ci-install
   - php console/console.php install-module avatars
-  - php console/console.php install-module userrank
   - php console/console.php install-module page
 
 script:
-  - htdocs/xoops_lib/vendor/bin/phpunit
-  - php git-phpcs.phar $TRAVIS_COMMIT_RANGE
+  - xoops_lib/vendor/bin/phpunit
+  - wget https://github.com/diff-sniffer/git/releases/download/0.1.0/git-phpcs.phar
+  - php git-phpcs.phar origin/$TRAVIS_BRANCH...$TRAVIS_PULL_REQUEST_SHA
 
 after_script:
   - if [ "$TRAVIS_PHP_VERSION" != "7.4snapshot" ] && [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,32 +5,32 @@ language: php
 php:
   - 7.1
   - 7.2
-  - nightly
+  - 7.3
+#  - 7.4snapshot
 
-matrix:
-  allow_failures:
-    - php: nightly
+#matrix:
+#  allow_failures:
+#    - php: 7.4snapshot
 
 before_install:
   - composer self-update
-  - cp composer.json.dist composer.json
 
 install:
-  - composer require xoops/base-requires:dev-master
-  - composer update
+  - composer --working-dir=htdocs/xoops_lib/ install
+  - wget https://github.com/diff-sniffer/git/releases/download/0.2.0/git-phpcs.phar
 
 before_script:
   - mysql -e 'create database xoops_test;'
   - php console/console.php ci-bootstrap
   - php console/console.php ci-install
   - php console/console.php install-module avatars
+  - php console/console.php install-module userrank
   - php console/console.php install-module page
 
 script:
-  - xoops_lib/vendor/bin/phpunit
-  - wget https://github.com/diff-sniffer/git/releases/download/0.1.0/git-phpcs.phar
-  - php git-phpcs.phar origin/$TRAVIS_BRANCH...$TRAVIS_PULL_REQUEST_SHA
+  - htdocs/xoops_lib/vendor/bin/phpunit
+  - php git-phpcs.phar $TRAVIS_COMMIT_RANGE
 
 after_script:
-  - if [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "7.4snapshot" ] && [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "7.4snapshot" ] && [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/tests/unit/class/xoopsmultimailerTest.php
+++ b/tests/unit/class/xoopsmultimailerTest.php
@@ -9,6 +9,6 @@ class XoopsMultiMailerTest extends \PHPUnit\Framework\TestCase
     {
         $x = new $this->myClass();
         $this->assertInstanceOf($this->myClass, $x);
-        $this->assertInstanceOf('\PHPMailer\PHPMailer\PHPMailer', $x);
+        $this->assertInstanceOf('\\PHPMailer\\PHPMailer\\PHPMailer', $x);
     }
 }

--- a/xoops_lib/Xoops/Core/Locale/Time.php
+++ b/xoops_lib/Xoops/Core/Locale/Time.php
@@ -120,7 +120,7 @@ class Time
                 $relPattern = null;
             } else {
                 $relKey = ($past) ? 'relativeTime-type-past' : 'relativeTime-type-future';
-                $rule = Plural::getRule($value, $locale);
+                $rule = Plural::getRuleOfType($value, Plural::RULETYPE_CARDINAL, $locale);
                 $relPattern = 'relativeTimePattern-count-' . $rule;
             }
         }

--- a/xoops_lib/Xoops/Core/Locale/Time.php
+++ b/xoops_lib/Xoops/Core/Locale/Time.php
@@ -102,7 +102,7 @@ class Time
             $value = $diff->i + (($diff->s > 30) ? 1 : 0);
         } elseif ($diff->s != 0) {
             $key = 'second';
-            $value = $diff->s;
+            $value = $diff->s + round($diff->f, 0);
         }
         if ($value==0) {
             $key = 'second';


### PR DESCRIPTION
Add PHP 7.3, drop nightly

Nightly is no longer 7.4, but 8.0dev. Too early for that.

7.4snapshot was added and commented out, as endroid/qr-code
requires gd, which is not in the snapshot, so composer build
fails.

Also fix:
- Compensate for microsecond rounding in Xoops\Core\Locale\Time
- XoopsMultiMailerTest instance test