### PR TITLE
added full debug message for Admin

### DIFF
--- a/xoops_lib/Xoops/Core/Logger.php
+++ b/xoops_lib/Xoops/Core/Logger.php
@@ -172,8 +172,13 @@ class Logger implements LoggerInterface
      */
     public function handleException($e)
     {
+        $xoops = \Xoops::getInstance();
         if ($this->isThrowable($e)) {
+            if ($xoops->isAdmin()) {
+                $msg = $e->xdebug_message;
+            } else {
             $msg = $e->getMessage();
+            }
             $this->reportFatalError($msg);
         }
     }


### PR DESCRIPTION
The $e->getMessage() is not enough for development. 

So instead of this:

![image](https://user-images.githubusercontent.com/613686/52908770-4b12c200-324a-11e9-8a86-9e6a0703e5e2.png)

we can have this:

![image](https://user-images.githubusercontent.com/613686/52908777-582fb100-324a-11e9-9dfa-b91279f19e41.png)
