### PR TITLE
Automatic autoload for modules

### DIFF
--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -87,10 +87,14 @@ $key = 'system/modules/autoload';
 $autoloadPrefixDirList = $xoops->cache()->cacheRead(
     $key,
     function () use ($xoops) {
-        $criteria = new CriteriaCompo(new Criteria('isactive', 1));
-        $criteria->add(new Criteria('namespace', '', '!='));
-        $moduleHandler = $xoops->getHandlerModule();
-        $autoloadModules = $moduleHandler->getObjectsArray($criteria);
+        try {
+            $criteria = new CriteriaCompo(new Criteria('isactive', 1));
+            $criteria->add(new Criteria('namespace', '', '!='));
+            $moduleHandler = $xoops->getHandlerModule();
+            $autoloadModules = $moduleHandler->getObjectsArray($criteria);
+        } catch (\Throwable $e) {
+            return [];
+        }
         $autoloadPrefixDirList = [];
         /** @var XoopsObject $almod */
         foreach ($autoloadModules as $almod) {

--- a/htdocs/modules/system/sql/schema.yml
+++ b/htdocs/modules/system/sql/schema.yml
@@ -725,7 +725,7 @@ tables:
                 type: string
                 default: ''
                 notnull: true
-                length: 25
+                length: 32
                 precision: 10
                 scale: 0
                 fixed: false
@@ -812,55 +812,53 @@ tables:
                 autoincrement: false
                 columnDefinition: null
                 comment: null
+            namespace:
+                name: namespace
+                type: string
+                default: null
+                notnull: false
+                length: 255
+                precision: 10
+                scale: 0
+                fixed: false
+                unsigned: false
+                autoincrement: false
+                columnDefinition: null
+                comment: null
+                collation: utf8mb4_unicode_ci
+            category:
+                name: category
+                type: string
+                default: null
+                notnull: false
+                length: 255
+                precision: 10
+                scale: 0
+                fixed: false
+                unsigned: false
+                autoincrement: false
+                columnDefinition: null
+                comment: null
+                collation: utf8mb4_unicode_ci
         indexes:
             PRIMARY:
                 name: PRIMARY
                 columns: [mid]
                 unique: true
                 primary: true
-            modules_hasmain:
-                name: modules_hasmain
-                columns: [hasmain]
-                unique: false
-                primary: false
-            modules_hasadmin:
-                name: modules_hasadmin
-                columns: [hasadmin]
-                unique: false
-                primary: false
-            modules_hassearch:
-                name: modules_hassearch
-                columns: [hassearch]
-                unique: false
-                primary: false
-            modules_hasnotification:
-                name: modules_hasnotification
-                columns: [hasnotification]
-                unique: false
-                primary: false
-            modules_dirname:
+            module_dirname:
                 name: modules_dirname
                 columns: [dirname]
-                unique: false
+                unique: true
                 primary: false
-            modules_name:
+            module_name:
                 name: modules_name
                 columns: [name]
                 unique: false
                 primary: false
-            modules_isactive:
-                name: modules_isactive
-                columns: [isactive]
-                unique: false
-                primary: false
-            modules_weight:
+            module_weight:
                 name: modules_weight
                 columns: [weight]
-                unique: false
-                primary: false
-            modules_hascomments:
-                name: modules_hascomments
-                columns: [hascomments]
                 unique: false
                 primary: false
     system_online:
@@ -2009,11 +2007,6 @@ tables:
             users_uiduname:
                 name: users_uiduname
                 columns: [uid, uname]
-                unique: false
-                primary: false
-            users_unamepass:
-                name: users_unamepass
-                columns: [uname, pass]
                 unique: false
                 primary: false
             users_level:

--- a/xoops_lib/Xoops/Core/Kernel/Handlers/XoopsModule.php
+++ b/xoops_lib/Xoops/Core/Kernel/Handlers/XoopsModule.php
@@ -18,6 +18,7 @@
 
 namespace Xoops\Core\Kernel\Handlers;
 
+use Xoops\Core\XoopsArray;
 use Xoops\Core\Kernel\Dtype;
 use Xoops\Core\Kernel\XoopsObject;
 
@@ -28,14 +29,13 @@ use Xoops\Core\Kernel\XoopsObject;
  * @package   Xoops\Core\Kernel
  * @author    Kazumi Ono <onokazu@xoops.org>
  * @author    Taiwen Jiang <phppp@users.sourceforge.net>
- * @copyright 2000-2015 XOOPS Project (http://xoops.org)
- * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
- * @link      http://xoops.org
+ * @copyright 2000-2019 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  */
 class XoopsModule extends XoopsObject
 {
     /**
-     * @var string
+     * @var array
      */
     public $modinfo;
 
@@ -63,14 +63,15 @@ class XoopsModule extends XoopsObject
         $this->initVar('last_update', Dtype::TYPE_INTEGER, null, false);
         $this->initVar('weight', Dtype::TYPE_INTEGER, 0, false);
         $this->initVar('isactive', Dtype::TYPE_INTEGER, 1, false);
-        $this->initVar('dirname', Dtype::TYPE_OTHER, null, true);
+        $this->initVar('dirname', Dtype::TYPE_TEXT_BOX, null, true);
         $this->initVar('hasmain', Dtype::TYPE_INTEGER, 0, false);
         $this->initVar('hasadmin', Dtype::TYPE_INTEGER, 0, false);
         $this->initVar('hassearch', Dtype::TYPE_INTEGER, 0, false);
         $this->initVar('hasconfig', Dtype::TYPE_INTEGER, 0, false);
         $this->initVar('hascomments', Dtype::TYPE_INTEGER, 0, false);
-        // RMV-NOTIFY
         $this->initVar('hasnotification', Dtype::TYPE_INTEGER, 0, false);
+        $this->initVar('namespace', Dtype::TYPE_TEXT_BOX, null, true);
+        $this->initVar('category', Dtype::TYPE_TEXT_BOX, null, true);
 
         $this->xoops_url = \XoopsBaseConfig::get('url');
         $this->xoops_root_path = \XoopsBaseConfig::get('root-path');
@@ -91,7 +92,9 @@ class XoopsModule extends XoopsObject
         if (!isset($this->modinfo)) {
             $this->loadInfo($dirname, $verbose);
         }
-        $this->setVar('name', $this->modinfo['name']);
+
+        $modInfoArray = new XoopsArray($this->modinfo);
+        $this->setVar('name', $modInfoArray->get('name'));
         // see @todo
         $versionPieces = explode('.', $this->modinfo['version']);
         if (count($versionPieces) > 2) {
@@ -99,21 +102,15 @@ class XoopsModule extends XoopsObject
         }
         $this->setVar('version', (int)(100 * ($this->modinfo['version'] + 0.001)));
         $this->setVar('dirname', $this->modinfo['dirname']);
-        $hasmain = (isset($this->modinfo['hasMain']) && $this->modinfo['hasMain'] == 1) ? 1 : 0;
-        $hasadmin = (isset($this->modinfo['hasAdmin']) && $this->modinfo['hasAdmin'] == 1) ? 1 : 0;
-        $hassearch = (isset($this->modinfo['hasSearch']) && $this->modinfo['hasSearch'] == 1) ? 1 : 0;
-        $hasconfig = ((isset($this->modinfo['config']) && is_array($this->modinfo['config']))
-            || !empty($this->modinfo['hasComments'])) ? 1 : 0;
-        $hascomments = (isset($this->modinfo['hasComments']) && $this->modinfo['hasComments'] == 1) ? 1 : 0;
-        // RMV-NOTIFY
-        $hasnotification = (isset($this->modinfo['hasNotification']) && $this->modinfo['hasNotification'] == 1) ? 1 : 0;
-        $this->setVar('hasmain', $hasmain);
-        $this->setVar('hasadmin', $hasadmin);
-        $this->setVar('hassearch', $hassearch);
-        $this->setVar('hasconfig', $hasconfig);
-        $this->setVar('hascomments', $hascomments);
-        // RMV-NOTIFY
-        $this->setVar('hasnotification', $hasnotification);
+
+        $this->setVar('hasmain', (bool) $modInfoArray->get('hasmain', false));
+        $this->setVar('hasadmin', (bool) $modInfoArray->get('hasadmin', false));
+        $this->setVar('hassearch', (bool) $modInfoArray->get('hassearch', false));
+        $this->setVar('hasconfig', ($modInfoArray->has('config') && is_array($modInfoArray->get('config'))) || (bool) $modInfoArray->get('hascomments', false));
+        $this->setVar('hascomments', (bool) $modInfoArray->get('hascomments', false));
+        $this->setVar('hasnotification', (bool) $modInfoArray->get('hasnotification', false));
+        $this->setVar('namespace', $modInfoArray->get('namespace'));
+        $this->setVar('category', $modInfoArray->get('category'));
     }
 
     /**

--- a/xoops_lib/Xoops/Core/Kernel/Handlers/XoopsModule.php
+++ b/xoops_lib/Xoops/Core/Kernel/Handlers/XoopsModule.php
@@ -90,7 +90,9 @@ class XoopsModule extends XoopsObject
     {
         $dirname = basename($dirname);
         if (!isset($this->modinfo)) {
-            $this->loadInfo($dirname, $verbose);
+            if (false === $this->loadInfo($dirname, $verbose)) {
+                return;
+            }
         }
 
         $modInfoArray = new XoopsArray($this->modinfo);


### PR DESCRIPTION
In xoops_version.php, set $modversion['namespace'] to the namespace for your module. A PSR4 autoloader will be created that will point to the 'src' directory in the module.

To aid in install and update, a temporary autoloader will be created to allow onInstall and onUpdate processes to have autoloading available.

Note: Update the system module to activate.