### PR TITLE
Bring ObjectTree into Xoops\Core

### DIFF
--- a/htdocs/class/tree.php
+++ b/htdocs/class/tree.php
@@ -1,4 +1,8 @@
 <?php
+
+use Xoops\Core\ObjectTree;
+use Xoops\Form\Select;
+
 /*
  You may not change or alter any portion of this comment or credits
  of supporting developers from this source code or any supporting source code
@@ -12,9 +16,8 @@
 /**
  * XOOPS tree class
  *
- * @copyright   2000-2017 XOOPS Project (http://xoops.org)
- * @license     GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
- * @package     class
+ * @copyright   2000-2019 XOOPS Project (https://xoops.org)
+ * @license     GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  * @since       2.0.0
  * @author      Kazumi Ono (http://www.myweb.ne.jp/, http://jp.xoops.org/)
  */
@@ -25,151 +28,31 @@
  * @package    Kernel
  * @subpackage Core
  * @author     Kazumi Ono <onokazu@xoops.org>
+ *
+ * @property-read array $_tree direct access to tree (deprecated)
  */
-class XoopsObjectTree
+class XoopsObjectTree extends ObjectTree
 {
-    /**
-     * @var string
-     */
-    protected $parentId;
-
-    /**
-     * @var string
-     */
-    protected $myId;
-
-    /**
-     * @var null|string
-     */
-    protected $rootId = null;
-
-    /**
-     * @var array
-     */
-    protected $tree = array();
-
-    /**
-     * @var array
-     */
-    protected $objects;
-
     /**
      * Constructor
      *
-     * @param array  $objectArr Array of {@link XoopsObject}s
-     * @param string $myId      field name of object ID
-     * @param string $parentId  field name of parent object ID
-     * @param string $rootId    field name of root object ID
+     * @param XoopsObject[] $objectArr array of XoopsObject that form the tree
+     * @param string        $myId      field name of the ID for each object
+     * @param string        $parentId  field name of the ID in each object of parent object
+     * @param string|null   $rootId    optional field name of the root object ID,
+     *                                 i.e. the top comment in a series of nested comments
      */
-    public function __construct(&$objectArr, $myId, $parentId, $rootId = null)
+    public function __construct($objectArr, $myId, $parentId, $rootId = null)
     {
-        $this->objects = $objectArr;
-        $this->myId     = $myId;
-        $this->parentId = $parentId;
-        if (isset($rootId)) {
-            $this->rootId = $rootId;
-        }
-        $this->initialize();
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        \Xoops::getInstance()->deprecated(
+            "XoopsObjectTree is deprecated, please use Xoops\\Core\\ObjectTree, " .
+            "accessed from {$trace[0]['file']} line {$trace[0]['line']},"
+        );
+        parent::__construct($objectArr, $myId, $parentId, $rootId);
     }
 
-    /**
-     * Initialize the object
-     *
-     * @access private
-     */
-    protected function initialize()
-    {
-        foreach (array_keys($this->objects) as $i) {
-            $key1                         = $this->objects[$i]->getVar($this->myId);
-            $this->tree[$key1]['obj']     = $this->objects[$i];
-            $key2                         = $this->objects[$i]->getVar($this->parentId);
-            $this->tree[$key1]['parent']  = $key2;
-            $this->tree[$key2]['child'][] = $key1;
-            if (isset($this->rootId)) {
-                $this->tree[$key1]['root'] = $this->objects[$i]->getVar($this->rootId);
-            }
-        }
-    }
 
-    /**
-     * Get the tree
-     *
-     * @return array Associative array comprising the tree
-     */
-    public function &getTree()
-    {
-        return $this->tree;
-    }
-
-    /**
-     * returns an object from the tree specified by its id
-     *
-     * @param  string $key ID of the object to retrieve
-     * @return XoopsObject Object within the tree
-     */
-    public function getByKey($key)
-    {
-        return $this->tree[$key]['obj'];
-    }
-
-    /**
-     * returns an array of all the first child object of an object specified by its id
-     *
-     * @param  string $key ID of the parent object
-     * @return array  Array of children of the parent
-     */
-    public function getFirstChild($key)
-    {
-        $ret = array();
-        if (isset($this->tree[$key]['child'])) {
-            foreach ($this->tree[$key]['child'] as $childKey) {
-                $ret[$childKey] = $this->tree[$childKey]['obj'];
-            }
-        }
-        return $ret;
-    }
-
-    /**
-     * returns an array of all child objects of an object specified by its id
-     *
-     * @param  string $key ID of the parent
-     * @param  array  $ret (Empty when called from client) Array of children from previous recursions.
-     * @return array  Array of child nodes.
-     */
-    public function getAllChild($key, $ret = array())
-    {
-        if (isset($this->tree[$key]['child'])) {
-            foreach ($this->tree[$key]['child'] as $childKey) {
-                $ret[$childKey] = $this->tree[$childKey]['obj'];
-                $children       = $this->getAllChild($childKey, $ret);
-                foreach (array_keys($children) as $newKey) {
-                    $ret[$newKey] = $children[$newKey];
-                }
-            }
-        }
-        return $ret;
-    }
-
-    /**
-     * returns an array of all parent objects.
-     * the key of returned array represents how many levels up from the specified object
-     *
-     * @param  string $key     ID of the child object
-     * @param  array  $ret     (empty when called from outside) Result from previous recursions
-     * @param  int    $upLevel (empty when called from outside) level of recursion
-     * @return array  Array of parent nodes.
-     */
-    public function getAllParent($key, $ret = array(), $upLevel = 1)
-    {
-        if (isset($this->tree[$key]['parent']) && isset($this->tree[$this->tree[$key]['parent']]['obj'])) {
-            $ret[$upLevel] = $this->tree[$this->tree[$key]['parent']]['obj'];
-            $parents       = $this->getAllParent($this->tree[$key]['parent'], $ret, $upLevel + 1);
-            foreach (array_keys($parents) as $newKey) {
-                $ret[$newKey] = $parents[$newKey];
-            }
-        }
-        return $ret;
-    }
 
     /**
      * Make options for a select box from
@@ -228,7 +111,10 @@ class XoopsObjectTree
         $extra = ''
     ) {
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
-        trigger_error("makeSelBox() is deprecated since 2.5.9, please use makeSelectElement(), accessed from {$trace[0]['file']} line {$trace[0]['line']},");
+        \Xoops::getInstance()->deprecated(
+            "makeSelBox() is deprecated since 2.5.9, please use makeSelectElement(), " .
+            "accessed from {$trace[0]['file']} line {$trace[0]['line']},"
+        );
         $ret = '<select name="' . $name . '" id="' . $name . '" ' . $extra . '>';
         if (false !== (bool)$addEmptyOption) {
             $ret .= '<option value="0"></option>';
@@ -251,7 +137,9 @@ class XoopsObjectTree
      * @param  string  $extra          extra content to add to the element
      * @param  string  $caption        optional caption for form element
      *
-     * @return XoopsFormSelect form element
+     * @return Select form element
+     *
+     * @deprecated use Xoops\Core\ObjectTree::makeSelect()
      */
     public function makeSelectElement(
         $name,
@@ -263,7 +151,7 @@ class XoopsObjectTree
         $extra = '',
         $caption = ''
     ) {
-        $element = new XoopsFormSelect($caption, $name, $selected);
+        $element = new Select($caption, $name, $selected);
         $element->setExtra($extra);
 
         if (false !== (bool)$addEmptyOption) {
@@ -272,33 +160,6 @@ class XoopsObjectTree
         $this->addSelectOptions($element, $fieldName, $key, $prefix);
 
         return $element;
-    }
-
-    /**
-     * Make options for a select box from
-     *
-     * @param XoopsFormSelect $element     form element to receive tree values as options
-     * @param string          $fieldName   Name of the member variable from the node objects that
-     *                                     should be used as the title for the options.
-     * @param int             $key         ID of the object to display as the root of select options
-     * @param string          $prefix_orig String to indent items at deeper levels
-     * @param string          $prefix_curr String to indent the current item
-     *
-     * @return void
-     */
-    protected function addSelectOptions($element, $fieldName, $key, $prefix_orig, $prefix_curr = '')
-    {
-        if ($key > 0) {
-            $value = $this->tree[$key]['obj']->getVar($this->myId);
-            $name = $prefix_curr . $this->tree[$key]['obj']->getVar($fieldName);
-            $element->addOption($value, $name);
-            $prefix_curr .= $prefix_orig;
-        }
-        if (isset($this->tree[$key]['child']) && !empty($this->tree[$key]['child'])) {
-            foreach ($this->tree[$key]['child'] as $childKey) {
-                $this->addSelectOptions($element, $fieldName, $childKey, $prefix_orig, $prefix_curr);
-            }
-        }
     }
 
     /**
@@ -316,7 +177,10 @@ class XoopsObjectTree
     {
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
         if ($name === '_tree') {
-            trigger_error("XoopsObjectTree::\$_tree is deprecated, accessed from {$trace[0]['file']} line {$trace[0]['line']},");
+            \Xoops::getInstance()->deprecated(
+                "XoopsObjectTree::\$_tree is deprecated since 2.5.9, please use makeSelectElement(), " .
+                "accessed from {$trace[0]['file']} line {$trace[0]['line']},"
+            );
             return $this->tree;
         }
         trigger_error(

--- a/tests/unit/xoopsLib/Xoops/Core/ObjectTreeTest.php
+++ b/tests/unit/xoopsLib/Xoops/Core/ObjectTreeTest.php
@@ -1,0 +1,69 @@
+<?php
+require_once(__DIR__.'/../../../init_new.php');
+
+use Xoops\Core\Kernel\XoopsObject;
+use Xoops\Core\ObjectTree;
+
+class ObjectTreeTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ObjectTree
+     */
+    protected $object;
+
+    private function getXoopsObjectDummy(): XoopsObject
+    {
+        return new class() extends XoopsObject{
+            public function __construct()
+            {
+                $this->initVar('id', XOBJ_DTYPE_INT, 0);
+                $this->initVar('pid', XOBJ_DTYPE_INT, 0);
+                $this->initVar('rootid', XOBJ_DTYPE_INT, 0);
+                parent::__construct();
+            }
+        };
+    }
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $objs = [];
+        ($objs[] = $this->getXoopsObjectDummy())->setVars(['id'=>1, 'pid'=>0, 'rootid'=>1]);
+        ($objs[] = $this->getXoopsObjectDummy())->setVars(['id'=>2, 'pid'=>1, 'rootid'=>1]);
+        ($objs[] = $this->getXoopsObjectDummy())->setVars(['id'=>3, 'pid'=>0, 'rootid'=>3]);
+        $this->object = new ObjectTree($objs, 'id', 'pid', 'rootid');
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+    }
+
+    public function testContracts()
+    {
+        $instance = $this->object;
+        $this->assertInstanceOf('\Xoops\Core\ObjectTree', $instance);
+    }
+
+
+    public function testGetByKey()
+    {
+        $obj=$this->object->getByKey(2);
+        $this->assertInstanceOf('Xoops\Core\Kernel\XoopsObject', $obj);
+        $this->assertEquals(2, $obj->getVar('id'));
+        $this->assertEquals(1, $obj->getVar('pid'));
+        $this->assertEquals(1, $obj->getVar('rootid'));
+    }
+
+    public function testGetAllParent()
+    {
+        $parents = $this->object->getAllParent(2);
+        $this->assertCount(1, $parents);
+    }
+}

--- a/xoops_lib/Xoops/Core/ObjectTree.php
+++ b/xoops_lib/Xoops/Core/ObjectTree.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Xoops\Core;
+
+use Xoops\Core\Kernel\XoopsObject;
+use Xoops\Form\Select;
+
+/*
+ You may not change or alter any portion of this comment or credits
+ of supporting developers from this source code or any supporting source code
+ which is considered copyrighted (c) material of the original comment or credit authors.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+/**
+ * Tree structures with XoopsObjects as nodes
+ *
+ * @category  Xoops\Core
+ * @package   ObjectTree
+ * @author    Kazumi Ono <onokazu@xoops.org>
+ * @copyright 2000-2019 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ */
+class ObjectTree
+{
+    /**
+     * @var string
+     */
+    protected $parentId;
+
+    /**
+     * @var string
+     */
+    protected $myId;
+
+    /**
+     * @var null|string
+     */
+    protected $rootId;
+
+    /**
+     * @var array;
+     */
+    protected $tree = [];
+
+    /**
+     * @var array
+     */
+    protected $objects;
+
+    /**
+     * Constructor
+     *
+     * @param XoopsObject[] $objectArr array of XoopsObject that form the tree
+     * @param string        $myId      field name of the ID for each object
+     * @param string        $parentId  field name of the ID in each object of parent object
+     * @param string|null   $rootId    optional field name of the root object ID,
+     *                                 i.e. the top comment in a series of nested comments
+     */
+    public function __construct($objectArr, $myId, $parentId, $rootId = null)
+    {
+        $this->objects = $objectArr;
+        $this->myId     = $myId;
+        $this->parentId = $parentId;
+        if (isset($rootId)) {
+            $this->rootId = $rootId;
+        }
+        $this->initialize();
+    }
+
+    /**
+     * Initialize the object
+     *
+     * @return void
+     */
+    protected function initialize(): void
+    {
+        foreach (array_keys($this->objects) as $i) {
+            $key1                         = $this->objects[$i]->getVar($this->myId);
+            $this->tree[$key1]['obj']     = $this->objects[$i];
+            $key2                         = $this->objects[$i]->getVar($this->parentId);
+            $this->tree[$key1]['parent']  = $key2;
+            $this->tree[$key2]['child'][] = $key1;
+            if (isset($this->rootId)) {
+                $this->tree[$key1]['root'] = $this->objects[$i]->getVar($this->rootId);
+            }
+        }
+    }
+
+    /**
+     * Get the tree
+     *
+     * @return array Associative array comprising the tree
+     */
+    public function getTree(): array
+    {
+        return $this->tree;
+    }
+
+    /**
+     * returns an object from the tree specified by its id
+     *
+     * @param  string $key ID of the object to retrieve
+     * @return XoopsObject Object within the tree
+     */
+    public function getByKey($key): XoopsObject
+    {
+        return $this->tree[$key]['obj'];
+    }
+
+    /**
+     * returns an array of all the first child object of an object specified by its id
+     *
+     * @param  string $key ID of the parent object
+     * @return array  Array of children of the parent
+     */
+    public function getFirstChild($key): array
+    {
+        $ret = [];
+        if (isset($this->tree[$key]['child'])) {
+            foreach ($this->tree[$key]['child'] as $childKey) {
+                $ret[$childKey] = $this->tree[$childKey]['obj'];
+            }
+        }
+        return $ret;
+    }
+
+    /**
+     * returns an array of all child objects of an object specified by its id
+     *
+     * @param  string $key ID of the parent
+     * @param  array  $ret (Empty when called from client) Array of children from previous recursions.
+     * @return array  Array of child nodes.
+     */
+    public function getAllChild($key, $ret = []): array
+    {
+        if (isset($this->tree[$key]['child'])) {
+            foreach ($this->tree[$key]['child'] as $childKey) {
+                $ret[$childKey] = $this->tree[$childKey]['obj'];
+                $children       = $this->getAllChild($childKey, $ret);
+                foreach (array_keys($children) as $newKey) {
+                    $ret[$newKey] = $children[$newKey];
+                }
+            }
+        }
+        return $ret;
+    }
+
+    /**
+     * returns an array of all parent objects.
+     * the key of returned array represents how many levels up from the specified object
+     *
+     * @param  int   $key     ID of the child object
+     * @param  array $ret     (empty when called from outside) Result from previous recursions
+     * @param  int   $upLevel (empty when called from outside) level of recursion
+     * @return array Array of parent nodes.
+     */
+    public function getAllParent($key, $ret = [], $upLevel = 1): array
+    {
+        if (isset($this->tree[$key]['parent']) && isset($this->tree[$this->tree[$key]['parent']]['obj'])) {
+            $ret[$upLevel] = $this->tree[$this->tree[$key]['parent']]['obj'];
+            $parents       = $this->getAllParent($this->tree[$key]['parent'], $ret, $upLevel + 1);
+            foreach (array_keys($parents) as $newKey) {
+                $ret[$newKey] = $parents[$newKey];
+            }
+        }
+        return $ret;
+    }
+
+    /**
+     * Make a select box with options from the tree
+     *
+     * This replaces makeSelectElement(). The parameters follow the Select element first, followed
+     * by the tree descriptions.
+     *
+     * The $extra parameter has been removed, as setExtra() is deprecated. Please use the Select
+     * object's attributes to add any required script for event handlers such as 'onSelect'.
+     *
+     * @param  string $caption        optional caption for form element
+     * @param  string $name           Name of the select box
+     * @param  string $selected       Value to display as selected
+     * @param  string $fieldName      Name of the member variable from the
+     *                                node objects that should be used as the title for the options.
+     * @param  string $prefix         String to indent deeper levels
+     * @param  bool   $addEmptyOption Set TRUE to add an empty option with value "0" at the top of the hierarchy
+     * @param  int    $key            ID of the object to display as the root of select options
+     *
+     * @return Select form element
+     */
+    public function makeSelect(
+        string $caption,
+        string $name,
+        string $selected,
+        string $fieldName,
+        string $prefix = '-',
+        bool $addEmptyOption = false,
+        int $key = 0
+    ): Select {
+        $element = new Select($caption, $name, $selected);
+
+        if (false !== $addEmptyOption) {
+            $element->addOption('0', ' ');
+        }
+        $this->addSelectOptions($element, $fieldName, $key, $prefix);
+
+        return $element;
+    }
+
+    /**
+     * Make options for a select box from
+     *
+     * @param Select $element     form element to receive tree values as options
+     * @param string $fieldName   Name of the member variable from the node objects that
+     *                            should be used as the title for the options.
+     * @param int    $key         ID of the object to display as the root of select options
+     * @param string $prefix_orig String to indent items at deeper levels
+     * @param string $prefix_curr String to indent the current item
+     *
+     * @return void
+     */
+    protected function addSelectOptions(
+        Select $element,
+        string $fieldName,
+        int $key,
+        string $prefix_orig,
+        string $prefix_curr = ''
+    ): void {
+        if ($key > 0) {
+            $value = $this->tree[$key]['obj']->getVar($this->myId);
+            $name = $prefix_curr . $this->tree[$key]['obj']->getVar($fieldName);
+            $element->addOption($value, $name);
+            $prefix_curr .= $prefix_orig;
+        }
+        if (isset($this->tree[$key]['child']) && !empty($this->tree[$key]['child'])) {
+            foreach ($this->tree[$key]['child'] as $childKey) {
+                $this->addSelectOptions($element, $fieldName, $childKey, $prefix_orig, $prefix_curr);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- introduces \Xoops\Core\ObjectTree
- Add new makeSelect() method with more FormElement like arguments
- removes makeSelectBox(), makeSelectElement() and $_tree, remain only for BC in legacy
- deprecating \XoopsObjectTree, remains for legacy BC
