### PR TITLE
Remove collapse class from nested comments

### DIFF
--- a/htdocs/modules/comments/templates/comments_nest.tpl
+++ b/htdocs/modules/comments/templates/comments_nest.tpl
@@ -11,7 +11,7 @@
 <!-- start comment replies -->
 {foreach item=reply from=$comments[i].replies}
     <br/>
-    <table class="bnone collapse">
+    <table class="bnone">
         <tr>
             <td width="{$reply.prefix}"></td>
             <td>


### PR DESCRIPTION
Causes comments to be hidden with no apparent mechanism to show.