### PR TITLE
Should read file, not load (string)

### DIFF
--- a/xoops_lib/Xmf/Database/TableLoad.php
+++ b/xoops_lib/Xmf/Database/TableLoad.php
@@ -63,7 +63,7 @@ class TableLoad
     {
         $count = 0;
 
-        $data = Yaml::loadWrapped($yamlFile); // work with phpmyadmin YAML dumps
+        $data = Yaml::readWrapped($yamlFile); // work with phpmyadmin YAML dumps
         if (false !== $data) {
             $count = static::loadTableFromArray($table, $data);
         }


### PR DESCRIPTION
This error has gone undetected in XMF in XOOPS 2.5 because the symfony/yaml component used there (2.x) accepts a filename to Yaml::parse(). This behavior was deprecated in 2.2 and removed in 3.0+.

Also fixed in XOOPS/xmf#61