### PR TITLE
Remove unused devDependencies

### DIFF
--- a/htdocs/class/xoopseditor/tinymce4/external_plugins/codemirror/CodeMirror/package.json
+++ b/htdocs/class/xoopseditor/tinymce4/external_plugins/codemirror/CodeMirror/package.json
@@ -7,8 +7,6 @@
                   "url": "http://codemirror.net/LICENSE"}],
     "directories": {"lib": "./lib"},
     "scripts": {"test": "node ./test/run.js"},
-    "devDependencies": {"node-static": "0.6.0",
-                        "phantomjs": "1.9.2-5"},
     "bugs": "http://github.com/marijnh/CodeMirror/issues",
     "keywords": ["JavaScript", "CodeMirror", "Editor"],
     "homepage": "http://codemirror.net",


### PR DESCRIPTION
The node-static package has known issues, and we do not use it.